### PR TITLE
Correctly round all partial integrations

### DIFF
--- a/src/cpu_util.c
+++ b/src/cpu_util.c
@@ -128,7 +128,7 @@ void xgpuReorderMatrix(Complex *matrix) {
 //check that GPU calculation matches the CPU
 //
 // verbose=0 means just print summary.
-// verbsoe=1 means print each differing basline/channel.
+// verbsoe=1 means print each differing baseline/channel.
 // verbose=2 and array_h!=0 means print each differing baseline and each input
 //           sample that contributed to it.
 #ifndef FIXED_POINT
@@ -152,11 +152,6 @@ void xgpuCheckResult(Complex *gpu, Complex *cpu, int verbose, ComplexInput *arra
 	  for(f=0; f<NFREQUENCY; f++){
 	    int k = f*(NSTATION+1)*(NSTATION/2) + i*(i+1)/2 + j;
 	    int index = (k*NPOL+pol1)*NPOL+pol2;
-
-#ifdef FIXED_POINT
-	    gpu[index].real = round(gpu[index].real);
-	    gpu[index].imag = round(gpu[index].imag);
-#endif
 
 	    if(zabs(cpu[index]) == 0) {
 	      error = zabs(gpu[index]);

--- a/src/cuda_xengine.cu
+++ b/src/cuda_xengine.cu
@@ -131,7 +131,7 @@ __device__ static void operator+=( float4 &a, const float4 b ) {
 }
 
 #ifdef FIXED_POINT
-#define make_float4_rnd(x, y, z, w) make_float4(round(x), round(y), round(z), round(w))
+#define make_float4_rnd(x, y, z, w) make_float4(rintf(x), rintf(y), rintf(z), rintf(w))
 #else
 #define make_float4_rnd(x, y, z, w) make_float4(x, y, z, w)
 #endif

--- a/src/cuda_xengine.cu
+++ b/src/cuda_xengine.cu
@@ -130,6 +130,12 @@ __device__ static void operator+=( float4 &a, const float4 b ) {
  a = t;
 }
 
+#ifdef FIXED_POINT
+#define make_float4_rnd(x, y, z, w) make_float4(round(x), round(y), round(z), round(w))
+#else
+#define make_float4_rnd(x, y, z, w) make_float4(x, y, z, w)
+#endif
+
 // device function to write out the matrix elements
 CUBE_DEVICE(static void, write2x2, unsigned int &Col, unsigned int &Row, float4 *matrix_real, float4 *matrix_imag, 
 	    float sum11XXreal, float sum11XXimag, float sum11XYreal, float sum11XYimag,
@@ -145,72 +151,72 @@ CUBE_DEVICE(static void, write2x2, unsigned int &Col, unsigned int &Row, float4 
 
 #if (MATRIX_ORDER == REGISTER_TILE_TRIANGULAR_ORDER) // write out the register tiles separately
   matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*0 + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum11XXreal, SCALE*sum11XYreal, SCALE*sum11YXreal, SCALE*sum11YYreal);
+    make_float4_rnd(SCALE*sum11XXreal, SCALE*sum11XYreal, SCALE*sum11YXreal, SCALE*sum11YYreal);
   matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*0 + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum11XXimag, SCALE*sum11XYimag, SCALE*sum11YXimag, SCALE*sum11YYimag);
+    make_float4_rnd(SCALE*sum11XXimag, SCALE*sum11XYimag, SCALE*sum11YXimag, SCALE*sum11YYimag);
 
   matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*1 + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum21XXreal, SCALE*sum21XYreal, SCALE*sum21YXreal, SCALE*sum21YYreal);
+    make_float4_rnd(SCALE*sum21XXreal, SCALE*sum21XYreal, SCALE*sum21YXreal, SCALE*sum21YYreal);
   matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*1 + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum21XXimag, SCALE*sum21XYimag, SCALE*sum21YXimag, SCALE*sum21YYimag);
+    make_float4_rnd(SCALE*sum21XXimag, SCALE*sum21XYimag, SCALE*sum21YXimag, SCALE*sum21YYimag);
 
   matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*3 + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum22XXreal, SCALE*sum22XYreal, SCALE*sum22YXreal, SCALE*sum22YYreal);
+    make_float4_rnd(SCALE*sum22XXreal, SCALE*sum22XYreal, SCALE*sum22YXreal, SCALE*sum22YYreal);
   matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*3 + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum22XXimag, SCALE*sum22XYimag, SCALE*sum22YXimag, SCALE*sum22YYimag);
+    make_float4_rnd(SCALE*sum22XXimag, SCALE*sum22XYimag, SCALE*sum22YXimag, SCALE*sum22YYimag);
   
   // Test if entire tile needs to be written or just 3 of 4 parts (exclude top-right)
   if (Col<Row) {
     matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*2 + (Row*(Row+1)/2) + Col] += 
-      make_float4(SCALE*sum12XXreal, SCALE*sum12XYreal, SCALE*sum12YXreal, SCALE*sum12YYreal);
+      make_float4_rnd(SCALE*sum12XXreal, SCALE*sum12XYreal, SCALE*sum12YXreal, SCALE*sum12YYreal);
     matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*2 + (Row*(Row+1)/2) + Col] += 
-      make_float4(SCALE*sum12XXimag, SCALE*sum12XYimag, SCALE*sum12YXimag, SCALE*sum12YYimag);
+      make_float4_rnd(SCALE*sum12XXimag, SCALE*sum12XYimag, SCALE*sum12YXimag, SCALE*sum12YYimag);
   }
 #elif (MATRIX_ORDER == REAL_IMAG_TRIANGULAR_ORDER) // write out the real and imaginary components separately
   Col*=2; Row*=2;
   matrix_real[f*NBASELINE + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum11XXreal, SCALE*sum11XYreal, SCALE*sum11YXreal, SCALE*sum11YYreal);
+    make_float4_rnd(SCALE*sum11XXreal, SCALE*sum11XYreal, SCALE*sum11YXreal, SCALE*sum11YYreal);
   matrix_imag[f*NBASELINE + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum11XXimag, SCALE*sum11XYimag, SCALE*sum11YXimag, SCALE*sum11YYimag);
+    make_float4_rnd(SCALE*sum11XXimag, SCALE*sum11XYimag, SCALE*sum11YXimag, SCALE*sum11YYimag);
 
   matrix_real[f*NBASELINE + ((Row+1)*(Row+2)/2) + Col] += 
-    make_float4(SCALE*sum21XXreal, SCALE*sum21XYreal, SCALE*sum21YXreal, SCALE*sum21YYreal);
+    make_float4_rnd(SCALE*sum21XXreal, SCALE*sum21XYreal, SCALE*sum21YXreal, SCALE*sum21YYreal);
   matrix_imag[f*NBASELINE + ((Row+1)*(Row+2)/2) + Col] += 
-    make_float4(SCALE*sum21XXimag, SCALE*sum21XYimag, SCALE*sum21YXimag, SCALE*sum21YYimag);
+    make_float4_rnd(SCALE*sum21XXimag, SCALE*sum21XYimag, SCALE*sum21YXimag, SCALE*sum21YYimag);
 
   matrix_real[f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1)] += 
-    make_float4(SCALE*sum22XXreal, SCALE*sum22XYreal, SCALE*sum22YXreal, SCALE*sum22YYreal);
+    make_float4_rnd(SCALE*sum22XXreal, SCALE*sum22XYreal, SCALE*sum22YXreal, SCALE*sum22YYreal);
   matrix_imag[f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1)] += 
-    make_float4(SCALE*sum22XXimag, SCALE*sum22XYimag, SCALE*sum22YXimag, SCALE*sum22YYimag);
+    make_float4_rnd(SCALE*sum22XXimag, SCALE*sum22XYimag, SCALE*sum22YXimag, SCALE*sum22YYimag);
   
   // Test if entire tile needs to be written or just 3 of 4 parts (exclude top-right)
   if (Col<Row) {
     matrix_real[f*NBASELINE + (Row*(Row+1)/2) + (Col+1)] += 
-      make_float4(SCALE*sum12XXreal, SCALE*sum12XYreal, SCALE*sum12YXreal, SCALE*sum12YYreal);
+      make_float4_rnd(SCALE*sum12XXreal, SCALE*sum12XYreal, SCALE*sum12YXreal, SCALE*sum12YYreal);
     matrix_imag[f*NBASELINE + (Row*(Row+1)/2) + (Col+1)] += 
-      make_float4(SCALE*sum12XXimag, SCALE*sum12XYimag, SCALE*sum12YXimag, SCALE*sum12YYimag);
+      make_float4_rnd(SCALE*sum12XXimag, SCALE*sum12XYimag, SCALE*sum12YXimag, SCALE*sum12YYimag);
   }
 #else  // standard triangular packed order
   Col*=2; Row*=2;
   matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + Col)*NPOL + 0] += 
-    make_float4(SCALE*sum11XXreal, SCALE*sum11XXimag, SCALE*sum11XYreal, SCALE*sum11XYimag);
+    make_float4_rnd(SCALE*sum11XXreal, SCALE*sum11XXimag, SCALE*sum11XYreal, SCALE*sum11XYimag);
   matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + Col)*NPOL + 1] += 
-    make_float4(SCALE*sum11YXreal, SCALE*sum11YXimag, SCALE*sum11YYreal, SCALE*sum11YYimag);
+    make_float4_rnd(SCALE*sum11YXreal, SCALE*sum11YXimag, SCALE*sum11YYreal, SCALE*sum11YYimag);
   matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + Col)*NPOL + 0] += 
-    make_float4(SCALE*sum21XXreal, SCALE*sum21XXimag, SCALE*sum21XYreal, SCALE*sum21XYimag);
+    make_float4_rnd(SCALE*sum21XXreal, SCALE*sum21XXimag, SCALE*sum21XYreal, SCALE*sum21XYimag);
   matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + Col)*NPOL + 1] += 
-    make_float4(SCALE*sum21YXreal, SCALE*sum21YXimag, SCALE*sum21YYreal, SCALE*sum21YYimag);
+    make_float4_rnd(SCALE*sum21YXreal, SCALE*sum21YXimag, SCALE*sum21YYreal, SCALE*sum21YYimag);
   matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1))*NPOL + 0] += 
-    make_float4(SCALE*sum22XXreal, SCALE*sum22XXimag, SCALE*sum22XYreal, SCALE*sum22XYimag);
+    make_float4_rnd(SCALE*sum22XXreal, SCALE*sum22XXimag, SCALE*sum22XYreal, SCALE*sum22XYimag);
   matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1))*NPOL + 1] += 
-    make_float4(SCALE*sum22YXreal, SCALE*sum22YXimag, SCALE*sum22YYreal, SCALE*sum22YYimag);
+    make_float4_rnd(SCALE*sum22YXreal, SCALE*sum22YXimag, SCALE*sum22YYreal, SCALE*sum22YYimag);
   
   // Test if entire tile needs to be written or just 3 of 4 parts (exclude top-right)
   if (Col<Row) {
     matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + (Col+1))*NPOL + 0] += 
-      make_float4(SCALE*sum12XXreal, SCALE*sum12XXimag, SCALE*sum12XYreal, SCALE*sum12XYimag);
+      make_float4_rnd(SCALE*sum12XXreal, SCALE*sum12XXimag, SCALE*sum12XYreal, SCALE*sum12XYimag);
     matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + (Col+1))*NPOL + 1] += 
-      make_float4(SCALE*sum12YXreal, SCALE*sum12YXimag, SCALE*sum12YYreal, SCALE*sum12YYimag);
+      make_float4_rnd(SCALE*sum12YXreal, SCALE*sum12YXimag, SCALE*sum12YYreal, SCALE*sum12YYimag);
   }
 #endif
 


### PR DESCRIPTION
This pull request will ensure that all visibilities are correctly rounded after each partial integration (`NTIME_PIPE`), ensuring that long-term integration cannot be affected by accumulation of trailing floating point ULP errors.  All visibilities will now also be represented as exact integers.

This only applies when doing 8-bit texture loaded data (FIXED_POINT), since this is where trailing ULP errors are introduced by the scaling of [-127,127] to [-1.0,1.0], which by definition is inexact.  Likely not the cause of data abnormalities seen in LEDA but fixing this rules this out.

@benbarsdell Assigning you to merge this pull request.
@jkocz Bringing to your attention so you can update LEDA correlator once @benbarsdell signs off on it.
