### PR TITLE
Feature/dp4a

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
-Release Notes for xGPU v0.0.1
------------------------------
+Release Notes for xGPU
+----------------------
 
 Overview:
 
@@ -163,8 +163,8 @@ Astronomy Cross-Correlation with Graphics Processing units",
 
 Authors:
 
-Michael Clark (NVIDIA)
+Kate Clark (NVIDIA)
 Paul La Plante (Loyola University Maryland)
 Lincoln Greenhill (Harvard-Smithsonian Center for Astrophysics)
 David MacMahon (University of California, Berkeley)
-Ben Barsdell (Harvard-Smithsonian Center for Astrophysics)
+Ben Barsdell (NVIDIA)

--- a/README
+++ b/README
@@ -7,24 +7,37 @@ xGPU is a library for performing the cross-multiplication step of the
 FX correlator algorithm, which is popular for radio astronomy signal
 processing.
 
+Precision:
+
+By default xGPU accepts signed 8-bit integer input, which is then
+converted to and computed in 32-bit floating point, with the final
+result output in 32-bit floating point.  However, on architectures
+that support the dp4a instruction (sm_61, sm_70 and sm_72 at the time
+of writing) a pure integer correlator is supported (8-bit integer
+multiply, 32-bit integer accumulation).  This can provide up to a 4x
+speedup versus using a floating point correlator.  Note, that if dp4a is
+requested on an unsupported architecture, then the computation will be
+emulated, providing the correct answer but much slower than native
+dp4a.
+
 Software Compatibility:
 
-The library has been tested under Linux (Ubuntu 10.04 and 10.10) and
-Mac OS X using release 4.0 of the CUDA toolkit.  Default compilation
-creates a 32-bit binary, so 64-bit systems will require 32-bit c and
-c++ libraries installed for cross-compilation (gcc and g++ multilib).
+The library has been tested under Linux (Ubuntu 16.04 and CentOS 7)
+using release 9.2 of the CUDA toolkit.  However the expectation is
+that all versions of CUDA should be compatible.
 
 Hardward Compatibility:
 
 For a list of supported devices see,
 
-http://www.nvidia.com/object/cuda_learn_products.html
+https://developer.nvidia.com/cuda-gpus
 
+xGPU has been tested and known to work on all GPUs from Fermi onwards.
 While this library will run on pre-Fermi GPUs with appropriate changes
 to the Makefile, note that the kernels make Fermi-specific
 optimizations and so will likely lead to sub-standard performance on
-sm1.x CUDA architectures.  Initial tuning has taken place for the
-Kepler architecture, but this is far from complete.
+sm1.x CUDA architectures.  Note that as of CUDA 9.0, Fermi support has been
+removed from the CUDA toolkit with Kepler being the minimum.
 
 Building the Library:
 
@@ -34,6 +47,43 @@ and running "make".
 
   $ cd src
   $ make
+
+The default architecture that is targeted is Kepler (sm_35), though
+this can be overriden with the CUDA_ARCH variable.  E.g.,
+
+  $ make CUDA_ARCH=sm_60
+
+would build xGPU for Pascal GP100.  The possible options are
+
+arch    example chips               example products                    dp4a
+sm_20   GF100, GF110                Tesla 2050, Tesla 2070
+sm_21   GF114, GF116                GTX 460
+sm_30   GK104, GK106, GK107         Tesla K10, GTX 680
+sm_35   GK110, GK180                Tesla K20, Tesla K40
+sm_50   GM107, GM108                GTX 750
+sm_52   GM200, GM204, GM206, GM207  Tesla M40, Tesla M40, GTX 980
+sm_53   GM20B                       Jetson TX1
+sm_60   GP100                       Tesla P100
+sm_61   GP102, GP104, GP106, GP107  Tesla P40, Tesla P4, GTX 1080       x
+sm_62   GP10B                       Jetson TX2
+sm_70   GV100                       Tesla V100, Titan V                 x
+sm_72   GV10B                       Xavier                              x
+
+In general one should target the same architecture that they are
+running on.  While code compiled for an older architecture will in
+general run on a more recent architecture, this may lead to
+sub-optimal performance.  For example, native dp4a instructions will
+only be generated for specific architectures.
+
+Other options include
+
+  CUDA_DIR    # path to CUDA toolkit installation (default /usr/local/cuda)
+  DEBUG       # set any specific compiler flags (default is -O3)
+  TEXTURE_DIM # whether to use 1-d or 2-d textures (default is 1)
+  DP4A        # whether to use dp4a instruction (default is no)
+
+For the full list of environment variables that control compilation
+and installation options see the top of src/Makefile.
 
 Currently, a number of sizing parameters must be specified when
 building the library.  Default values of these parameters are
@@ -45,12 +95,12 @@ with there default values.
   NPOL=2
   NSTATION=256
   NFREQUENCY=10
-  NTIME=1000
-  NTIME_PIPE=100
+  NTIME=1024
+  NTIME_PIPE=128
 
-Note that NTIME_PIPE must be a multiple of 4 and NTIME must be a
-multiple of NTIME_PIPE.  The preprocessor will error out if those two
-conditions are not met.
+Note that NTIME_PIPE must be a multiple of 4 (16 when dp4a is used)
+and NTIME must be a multiple of NTIME_PIPE.  The preprocessor will
+error out if those two conditions are not met.
 
 For example, to compile with NSTATION set to 128 and all other
 parameters at their default values:

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@ endif
 
 DEBUG ?= -O3
 TEXTURE_DIM ?= 1
-CUDA_ARCH ?= sm_20
+CUDA_ARCH ?= sm_30
 
 NVCC = $(CUDA_DIR)/bin/nvcc
 prefix ?= /usr/local
@@ -44,7 +44,7 @@ RPATH = -Xlinker -rpath,'$${ORIGIN}:$${ORIGIN}/../lib'
 LIBXGPU = libxgpu.so
 endif
 
-NVCCFLAGS += $(DEBUG) -arch=$(CUDA_ARCH) -Xptxas -abi=no --ptxas-options=-v -prec-sqrt=false -Xcompiler -fPIC 
+NVCCFLAGS += $(DEBUG) -arch=$(CUDA_ARCH) --ptxas-options=-v -prec-sqrt=false -Xcompiler -fPIC
 NVCCFLAGS += -DTEXTURE_DIM=$(TEXTURE_DIM)
 
 ifeq ($(strip $(CUDA_ARCH)),sm_35)
@@ -134,6 +134,12 @@ endif
 # this sets the pipeline to run in an infinite loop - for power measurement
 ifeq ($(strip $(POWER_LOOP)), yes)
 NVCCFLAGS += -DPOWER_LOOP
+endif
+
+# If DP4A is defined, the library does all computation using native
+# 8-bit integer multiplication and 32-bit accumulation
+ifeq ($(strip $(DP4A)), yes)
+NVCCFLAGS += -DDP4A
 endif
 
 ifdef RUNTIME_STATS

--- a/src/cpu_util.c
+++ b/src/cpu_util.c
@@ -235,8 +235,8 @@ void xgpuCheckResult(Complex *gpu, Complex *cpu, int verbose, ComplexInput *arra
 void xgpuSwizzleInput(ComplexInput *out, const ComplexInput *in) {
   printf("Swizzling input\n");
 
-  char *o = (char*)out;
-  const char *i = (char*)in;
+  signed char *o = (signed char*)out;
+  const signed char *i = (signed char*)in;
   int t, f, s, p, c;
 
   for (t=0; t<NTIME_PIPE; t++) {

--- a/src/cpu_util.c
+++ b/src/cpu_util.c
@@ -244,7 +244,7 @@ void xgpuSwizzleInput(ComplexInput *out, const ComplexInput *in) {
       for(s=0; s<NSTATION; s++) {
 	for (p=0; p<NPOL; p++) {
 	  for (c=0; c<2; c++) {
-	    o[((((c*(NTIME_PIPE/4)+t/4)*NFREQUENCY+f)*NSTATION+s)*NPOL+p)*4+t%4] =
+	    o[((((t/4*NFREQUENCY+f)*NSTATION+s)*NPOL+p)*2+c)*4+t%4] =
 	      i[( ( (t*NFREQUENCY+f)*NSTATION+s )*NPOL+p )*2 + c];
 	  }
 	}

--- a/src/cpu_util.c
+++ b/src/cpu_util.c
@@ -178,11 +178,12 @@ void xgpuCheckResult(Complex *gpu, Complex *cpu, int verbose, ComplexInput *arra
 	    }
 	    if(error > TOL) {
               if(verbose > 0) {
+                if (errorCount==0) printf("freq  i   j    k px py  linear   cpu.real      gpu.real     xcpu.imag      gpu.imag abs(cpu) abs(gpu)\n");
 #ifndef DP4A
-                printf("%d %d %d %d %d %d %d %g  %g  %g  %g (%g %g)\n", f, i, j, k, pol1, pol2, index,
+                printf("%3d %3d %3d %4d %2d %2d %5d %12g  %12g  %12g  %12g (%g %g)\n", f, i, j, k, pol1, pol2, index,
                        cpu[index].real, gpu[index].real, cpu[index].imag, gpu[index].imag, zabs(cpu[index]), zabs(gpu[index]));
 #else
-                printf("%3d %3d %3d %4d %1d %1d %5d %12d  %12d  %12d  %12d (%g %g)\n", f, i, j, k, pol1, pol2, index,
+                printf("%3d %3d %3d %4d %2d %2d %5d %12d  %12d  %12d  %12d (%g %g)\n", f, i, j, k, pol1, pol2, index,
                        cpu[index].real, gpu[index].real, cpu[index].imag, gpu[index].imag, zabs(cpu[index]), zabs(gpu[index]));
 #endif
                 if(verbose > 1 && array_h) {
@@ -238,7 +239,7 @@ void xgpuSwizzleInput(ComplexInput *out, const ComplexInput *in) {
   const signed char *i = (signed char*)in;
   int t, f, s, p, c;
 
-  for (t=0; t<NTIME_PIPE; t++) {
+  for (t=0; t<NTIME; t++) {
     for (f=0; f<NFREQUENCY; f++) {
       for(s=0; s<NSTATION; s++) {
 	for (p=0; p<NPOL; p++) {

--- a/src/cuda_xengine.cu
+++ b/src/cuda_xengine.cu
@@ -19,15 +19,6 @@
 #include "xgpu_version.h"
 #include "cube/cube.h"
 
-// Set data types accordingly
-#ifndef FIXED_POINT
-#define COMPLEX_INPUT float2
-#define SCALE 1.0f // no rescale required for FP32
-#else
-#define COMPLEX_INPUT char2 
-#define SCALE 16129.0f // need to rescale result 
-#endif // FIXED_POINT
-
 // whether we are writing the matrix back to device memory (used for benchmarking)
 static int writeMatrix = 1;
 // this must be enabled for this option to work though, slightly hurts performance
@@ -84,9 +75,15 @@ typedef struct XGPUInternalContextStruct {
 static texture<float2, 1, cudaReadModeElementType> tex1dfloat2;
 static texture<float2, 2, cudaReadModeElementType> tex2dfloat2;
 #else
+#ifdef DP4A
+// texture declaration for swizzled 8-bit fixed point reads
+static texture<char4, 1, cudaReadModeElementType> tex1dchar4;
+static texture<char4, 2, cudaReadModeElementType> tex2dchar4;
+#else
 // texture declaration for 8-bit fixed point reads
 static texture<char2, 1, cudaReadModeNormalizedFloat> tex1dfloat2;
 static texture<char2, 2, cudaReadModeNormalizedFloat> tex2dfloat2;
+#endif
 #endif
 
 // array holding indices for which matrix we are doing the output to at a given iteration
@@ -111,318 +108,7 @@ static __device__ __constant__ unsigned char tIndex[PIPE_LENGTH*NFREQUENCY];
 #define PRINT_ELAPASED(f,t)
 #endif
 
-//determine row and column from blockIdx.x
-CUBE_DEVICE(static void, findPosition, unsigned int &Col, unsigned int &Row, unsigned int &blockX, unsigned int &blockY) {
-  unsigned int k = blockIdx.x;
-#if NSTATION >= 512
-  blockY = -0.5 + sqrt(0.25 + 2*k);
-#else
-  blockY = -0.5f + sqrtf(0.25f + 2*k);
-#endif  
-  blockX = k - (((blockY+1)*(blockY)) >> 1);
-  Row = (blockY*TILE_HEIGHT + threadIdx.y);
-  Col = (blockX*TILE_WIDTH + threadIdx.x);
-}
-
-__device__ static void operator+=( float4 &a, const float4 b ) {
- float4 t = a;
- t.x += b.x; t.y += b.y; t.z += b.z; t.w += b.w;
- a = t;
-}
-
-// device function to write out the matrix elements
-CUBE_DEVICE(static void, write2x2, unsigned int &Col, unsigned int &Row, float4 *matrix_real, float4 *matrix_imag, 
-	    float sum11XXreal, float sum11XXimag, float sum11XYreal, float sum11XYimag,
-	    float sum11YXreal, float sum11YXimag, float sum11YYreal, float sum11YYimag,
-	    float sum12XXreal, float sum12XXimag, float sum12XYreal, float sum12XYimag,
-	    float sum12YXreal, float sum12YXimag, float sum12YYreal, float sum12YYimag,
-	    float sum21XXreal, float sum21XXimag, float sum21XYreal, float sum21XYimag,
-	    float sum21YXreal, float sum21YXimag, float sum21YYreal, float sum21YYimag,
-	    float sum22XXreal, float sum22XXimag, float sum22XYreal, float sum22XYimag,
-	    float sum22YXreal, float sum22YXimag, float sum22YYreal, float sum22YYimag) {
-  
-  int f=blockIdx.y;
-
-#if (MATRIX_ORDER == REGISTER_TILE_TRIANGULAR_ORDER) // write out the register tiles separately
-  matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*0 + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum11XXreal, SCALE*sum11XYreal, SCALE*sum11YXreal, SCALE*sum11YYreal);
-  matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*0 + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum11XXimag, SCALE*sum11XYimag, SCALE*sum11YXimag, SCALE*sum11YYimag);
-
-  matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*1 + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum21XXreal, SCALE*sum21XYreal, SCALE*sum21YXreal, SCALE*sum21YYreal);
-  matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*1 + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum21XXimag, SCALE*sum21XYimag, SCALE*sum21YXimag, SCALE*sum21YYimag);
-
-  matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*3 + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum22XXreal, SCALE*sum22XYreal, SCALE*sum22YXreal, SCALE*sum22YYreal);
-  matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*3 + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum22XXimag, SCALE*sum22XYimag, SCALE*sum22YXimag, SCALE*sum22YYimag);
-  
-  // Test if entire tile needs to be written or just 3 of 4 parts (exclude top-right)
-  if (Col<Row) {
-    matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*2 + (Row*(Row+1)/2) + Col] += 
-      make_float4(SCALE*sum12XXreal, SCALE*sum12XYreal, SCALE*sum12YXreal, SCALE*sum12YYreal);
-    matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*2 + (Row*(Row+1)/2) + Col] += 
-      make_float4(SCALE*sum12XXimag, SCALE*sum12XYimag, SCALE*sum12YXimag, SCALE*sum12YYimag);
-  }
-#elif (MATRIX_ORDER == REAL_IMAG_TRIANGULAR_ORDER) // write out the real and imaginary components separately
-  Col*=2; Row*=2;
-  matrix_real[f*NBASELINE + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum11XXreal, SCALE*sum11XYreal, SCALE*sum11YXreal, SCALE*sum11YYreal);
-  matrix_imag[f*NBASELINE + (Row*(Row+1)/2) + Col] += 
-    make_float4(SCALE*sum11XXimag, SCALE*sum11XYimag, SCALE*sum11YXimag, SCALE*sum11YYimag);
-
-  matrix_real[f*NBASELINE + ((Row+1)*(Row+2)/2) + Col] += 
-    make_float4(SCALE*sum21XXreal, SCALE*sum21XYreal, SCALE*sum21YXreal, SCALE*sum21YYreal);
-  matrix_imag[f*NBASELINE + ((Row+1)*(Row+2)/2) + Col] += 
-    make_float4(SCALE*sum21XXimag, SCALE*sum21XYimag, SCALE*sum21YXimag, SCALE*sum21YYimag);
-
-  matrix_real[f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1)] += 
-    make_float4(SCALE*sum22XXreal, SCALE*sum22XYreal, SCALE*sum22YXreal, SCALE*sum22YYreal);
-  matrix_imag[f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1)] += 
-    make_float4(SCALE*sum22XXimag, SCALE*sum22XYimag, SCALE*sum22YXimag, SCALE*sum22YYimag);
-  
-  // Test if entire tile needs to be written or just 3 of 4 parts (exclude top-right)
-  if (Col<Row) {
-    matrix_real[f*NBASELINE + (Row*(Row+1)/2) + (Col+1)] += 
-      make_float4(SCALE*sum12XXreal, SCALE*sum12XYreal, SCALE*sum12YXreal, SCALE*sum12YYreal);
-    matrix_imag[f*NBASELINE + (Row*(Row+1)/2) + (Col+1)] += 
-      make_float4(SCALE*sum12XXimag, SCALE*sum12XYimag, SCALE*sum12YXimag, SCALE*sum12YYimag);
-  }
-#else  // standard triangular packed order
-  Col*=2; Row*=2;
-  matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + Col)*NPOL + 0] += 
-    make_float4(SCALE*sum11XXreal, SCALE*sum11XXimag, SCALE*sum11XYreal, SCALE*sum11XYimag);
-  matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + Col)*NPOL + 1] += 
-    make_float4(SCALE*sum11YXreal, SCALE*sum11YXimag, SCALE*sum11YYreal, SCALE*sum11YYimag);
-  matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + Col)*NPOL + 0] += 
-    make_float4(SCALE*sum21XXreal, SCALE*sum21XXimag, SCALE*sum21XYreal, SCALE*sum21XYimag);
-  matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + Col)*NPOL + 1] += 
-    make_float4(SCALE*sum21YXreal, SCALE*sum21YXimag, SCALE*sum21YYreal, SCALE*sum21YYimag);
-  matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1))*NPOL + 0] += 
-    make_float4(SCALE*sum22XXreal, SCALE*sum22XXimag, SCALE*sum22XYreal, SCALE*sum22XYimag);
-  matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1))*NPOL + 1] += 
-    make_float4(SCALE*sum22YXreal, SCALE*sum22YXimag, SCALE*sum22YYreal, SCALE*sum22YYimag);
-  
-  // Test if entire tile needs to be written or just 3 of 4 parts (exclude top-right)
-  if (Col<Row) {
-    matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + (Col+1))*NPOL + 0] += 
-      make_float4(SCALE*sum12XXreal, SCALE*sum12XXimag, SCALE*sum12XYreal, SCALE*sum12XYimag);
-    matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + (Col+1))*NPOL + 1] += 
-      make_float4(SCALE*sum12YXreal, SCALE*sum12YXimag, SCALE*sum12YYreal, SCALE*sum12YYimag);
-  }
-#endif
-
-}
-
-#ifndef COMPLEX_BLOCK_SIZE
-#define COMPLEX_BLOCK_SIZE 1
-#endif
-
-#if COMPLEX_BLOCK_SIZE != 1 && COMPLEX_BLOCK_SIZE != 32
-#error COMPLEX_BLOCK_SIZE must be 1 or 32
-#endif
-
-//#define STRUCT_OF_ARRAY
-
-// Use the appropriate shared memory load / store routines according to the atomic size
-#if SHARED_ATOMIC_SIZE == 4
-#include "shared_transfer_4.cuh"
-#elif SHARED_ATOMIC_SIZE == 8
-#include "shared_transfer_8.cuh"
-#else
-#error SHARED_ATOMIC_SIZE must be 4 or 8
-#endif
-
-CUBE_KERNEL(static shared2x2float2, float4 *matrix_real, float4 *matrix_imag, const int Nstation, const int write)
-{
-  CUBE_START;
-
-// Set the degree of shared memory buffering to use
-#if __CUDA_ARCH__ < 300 
-#define BUFFER_DEPTH 2 // Fermi optimal setting
-#else 
-#define BUFFER_DEPTH 4 // Kepler optimal setting
-#endif
-
-  //get local thread ID
-  unsigned int ty = threadIdx.y;
-  unsigned int tx = threadIdx.x;
-  unsigned int tid = ty*TILE_WIDTH + tx;
-
-  //set frequency number from blockIdx.y
-  unsigned int f = blockIdx.y;
-
-  unsigned int Row, Col, blockX, blockY;
-  CUBE_DEVICE_CALL(findPosition, Col, Row, blockX, blockY);
-
-  //declare shared memory for input coalescing
-
-#if SHARED_ATOMIC_SIZE == 4
-  __shared__ float input[BUFFER_DEPTH][16*TILE_WIDTH]; // 4* for float4, 4* for 2x2 tile size
-  float *input0_p = input[0] + tid;
-  float *input1_p = input[1] + tid;
-#if BUFFER_DEPTH == 4
-  float *input2_p = input[2] + tid;
-  float *input3_p = input[3] + tid;
-#endif // BUFFER_DEPTH==4
-#else
-  __shared__ float2 input[BUFFER_DEPTH][8*TILE_WIDTH]; // 2* for float4/float2, 4* for 2x2 tile size
-
-#ifdef STRUCT_OF_ARRAY
-  unsigned swizzled_tid = ((tid & 0x1c) >> 1) | ((tid & 2)    << 3) | (tid & 0x21);
-  float2 *input0_p = input[0] + swizzled_tid;
-  float2 *input1_p = input[1] + swizzled_tid;
-#if BUFFER_DEPTH == 4
-  float2 *input2_p = input[2] + swizzled_tid;
-  float2 *input3_p = input[3] + swizzled_tid;
-#endif // BUFFER_DEPTH==4
-
-#else
-
-  float2 *input0_p = input[0] + tid;
-  float2 *input1_p = input[1] + tid;
-#if BUFFER_DEPTH == 4
-  float2 *input2_p = input[2] + tid;
-  float2 *input3_p = input[3] + tid;
-#endif // BUFFER_DEPTH==4
-#endif // STRUCT_OF_ARRAY
-
-#endif
-
-  //instantiate sum variables
-  float sum11XXreal = 0.0, sum11XXimag = 0.0;
-  float sum11XYreal = 0.0, sum11XYimag = 0.0;
-  float sum11YXreal = 0.0, sum11YXimag = 0.0;
-  float sum11YYreal = 0.0, sum11YYimag = 0.0;
-  float sum12XXreal = 0.0, sum12XXimag = 0.0;
-  float sum12XYreal = 0.0, sum12XYimag = 0.0;
-  float sum12YXreal = 0.0, sum12YXimag = 0.0;
-  float sum12YYreal = 0.0, sum12YYimag = 0.0;
-  float sum21XXreal = 0.0, sum21XXimag = 0.0;
-  float sum21XYreal = 0.0, sum21XYimag = 0.0;
-  float sum21YXreal = 0.0, sum21YXimag = 0.0;
-  float sum21YYreal = 0.0, sum21YYimag = 0.0;
-  float sum22XXreal = 0.0, sum22XXimag = 0.0;
-  float sum22XYreal = 0.0, sum22XYimag = 0.0;
-  float sum22YXreal = 0.0, sum22YXimag = 0.0;
-  float sum22YYreal = 0.0, sum22YYimag = 0.0;
-
-#if SHARED_ATOMIC_SIZE == 8
-#if COMPLEX_BLOCK_SIZE != 1
-#error COMPLEX_BLOCK_SIZE must be 1 for SHARED_ATOMIC_SIZE == 8 (for now)
-#endif
-#endif
-
-  unsigned int array_index = f*Nstation*NPOL + tid;
-
-  if (tid < 4*TILE_WIDTH) {
-    // Read in column in first warp
-    array_index += 2*blockX*TILE_WIDTH*NPOL;
-  } else {
-    // Read in row in second warp
-    array_index += 2*blockY*TILE_WIDTH*NPOL - 4*TILE_HEIGHT;    
-#if SHARED_ATOMIC_SIZE == 4
-    // threads 32..63 now have offset 64..95
-    input0_p += 4*TILE_WIDTH;
-    input1_p += 4*TILE_WIDTH;
-#if BUFFER_DEPTH==4
-    input2_p += 4*TILE_WIDTH;
-    input3_p += 4*TILE_WIDTH;
-#endif // BUFFER_DEPTH=4
-#endif
-  }
-
-#if BUFFER_DEPTH==2
-  LOAD(0, 0);
-#elif BUFFER_DEPTH==4
-  LOAD(0, 0);
-  LOAD(1, 1);
-#endif
-
-#if __CUDA_ARCH__ < 300
-#pragma unroll 2
-#else
-#pragma unroll 1
-#endif
-  for(unsigned int t=0; t<NTIME_PIPE-BUFFER_DEPTH; t+=BUFFER_DEPTH){
-
-    __syncthreads();
-
-#if BUFFER_DEPTH==2
-    TWO_BY_TWO_COMPUTE(0);
-    LOAD(1, t+1);
-#elif BUFFER_DEPTH==4
-    TWO_BY_TWO_COMPUTE(0);
-    TWO_BY_TWO_COMPUTE(1);
-    LOAD(2, t+2);
-    LOAD(3, t+3);
-#endif
-
-    __syncthreads();
-
-
-#if BUFFER_DEPTH==2
-    TWO_BY_TWO_COMPUTE(1);
-    LOAD(0, t+2);
-#elif BUFFER_DEPTH==4
-    TWO_BY_TWO_COMPUTE(2);
-    TWO_BY_TWO_COMPUTE(3);
-    LOAD(0, t+4);
-    LOAD(1, t+5);
-#endif
-
-  } 
-
-  __syncthreads();  
-
-#if BUFFER_DEPTH==2
-  TWO_BY_TWO_COMPUTE(0);
-  LOAD(1, NTIME_PIPE-1);
-#elif BUFFER_DEPTH==4
-  TWO_BY_TWO_COMPUTE(0);
-  TWO_BY_TWO_COMPUTE(1);
-  LOAD(2, NTIME_PIPE-2);
-  LOAD(3, NTIME_PIPE-1);
-#endif
-
-  __syncthreads();
-
-#if BUFFER_DEPTH==2
-  TWO_BY_TWO_COMPUTE(1);
-#elif BUFFER_DEPTH==4
-  TWO_BY_TWO_COMPUTE(2);
-  TWO_BY_TWO_COMPUTE(3);
-#endif
-
-  if (Col > Row) return; // writes seem faster when this is pulled up here
-
-#ifdef WRITE_OPTION
-  if (write) {
-#endif
-    CUBE_DEVICE_CALL(write2x2, Col, Row, matrix_real, matrix_imag,
-		     sum11XXreal, sum11XXimag, sum11XYreal, sum11XYimag, 
-		     sum11YXreal, sum11YXimag, sum11YYreal, sum11YYimag, 
-		     sum12XXreal, sum12XXimag, sum12XYreal, sum12XYimag, 
-		     sum12YXreal, sum12YXimag, sum12YYreal, sum12YYimag, 
-		     sum21XXreal, sum21XXimag, sum21XYreal, sum21XYimag, 
-		     sum21YXreal, sum21YXimag, sum21YYreal, sum21YYimag, 
-		     sum22XXreal, sum22XXimag, sum22XYreal, sum22XYimag, 
-		     sum22YXreal, sum22YXimag, sum22YYreal, sum22YYimag);
-
-    CUBE_ADD_BYTES(Col < Row ? 256 : 192); // need load and save
-#ifdef WRITE_OPTION
-  }
-#endif
-
-  CUBE_ADD_FLOPS(NTIME_PIPE*(Col < Row ? 128 : 96));
-
-  CUBE_END;
-}
-
-#undef LOAD
-#undef TWO_BY_TWO_COMPUTE
+#include "kernel.cuh"
 
 static XGPUInfo compiletime_info = {
   .npol =        NPOL,
@@ -435,6 +121,11 @@ static XGPUInfo compiletime_info = {
   .input_type =  XGPU_INT8,
 #else
   .input_type =  XGPU_FLOAT32,
+#endif
+#ifdef DP4A
+  .compute_type = XGPU_INT8,
+#else
+  .compute_type = XGPU_FLOAT32,
 #endif
   .vecLength  =  NFREQUENCY * NTIME * NSTATION * NPOL,
   .vecLengthPipe = NFREQUENCY * NTIME_PIPE * NSTATION * NPOL,
@@ -470,6 +161,7 @@ void xgpuInfo(XGPUInfo *pcxs)
   pcxs->ntime          = compiletime_info.ntime;
   pcxs->ntimepipe      = compiletime_info.ntimepipe;
   pcxs->input_type     = compiletime_info.input_type;
+  pcxs->compute_type   = compiletime_info.compute_type;
   pcxs->vecLength      = compiletime_info.vecLength;
   pcxs->vecLengthPipe  = compiletime_info.vecLengthPipe;
   pcxs->matLength      = compiletime_info.matLength;
@@ -577,7 +269,15 @@ int xgpuInit(XGPUContext *context, int device_flags)
   }
   checkCudaError();
 
-  internal->channelDesc = cudaCreateChannelDesc<COMPLEX_INPUT>();
+#ifndef FIXED_POINT
+  internal->channelDesc = cudaCreateChannelDesc<float2>();
+#else
+#ifdef DP4A
+  internal->channelDesc = cudaCreateChannelDesc<char4>();
+#else
+  internal->channelDesc = cudaCreateChannelDesc<char2>();
+#endif // DP4A
+#endif // FIXED_POINT
 
 #if NPULSAR > 0
   unsigned char timeIndex[PIPE_LENGTH*NFREQUENCY];
@@ -851,8 +551,13 @@ int xgpuCudaXengine(XGPUContext *context, int syncOp)
   cudaChannelFormatDesc channelDesc = internal->channelDesc;
 
   // set pointers to the real and imaginary components of the device matrix
+#ifndef DP4A
   float4 *matrix_real_d = (float4 *)(internal->matrix_d);
   float4 *matrix_imag_d = (float4 *)(internal->matrix_d + compiletime_info.matLength/2);
+#else
+  int4 *matrix_real_d = (int4 *)(internal->matrix_d);
+  int4 *matrix_imag_d = (int4 *)(internal->matrix_d + compiletime_info.matLength/2);
+#endif
 
   int Nblock = compiletime_info.nstation/min(TILE_HEIGHT,TILE_WIDTH);
   ComplexInput *array_load;
@@ -889,10 +594,14 @@ int xgpuCudaXengine(XGPUContext *context, int syncOp)
     cudaBindTexture2D(0, tex2dfloat2, array_compute, channelDesc, NFREQUENCY*NSTATION*NPOL, NTIME_PIPE, 
 		      NFREQUENCY*NSTATION*NPOL*sizeof(ComplexInput));
 #else
+#ifndef DP4A
     cudaBindTexture(0, tex1dfloat2, array_compute, channelDesc, NFREQUENCY*NSTATION*NPOL*NTIME_PIPE*sizeof(ComplexInput));
+#else
+    cudaBindTexture(0, tex1dchar4, array_compute, channelDesc, NFREQUENCY*NSTATION*NPOL*2*NTIME_PIPE*sizeof(char4)/4);
+#endif
 #endif
     cudaStreamWaitEvent(streams[1], copyCompletion[(p+1)%2], 0); // only start the kernel once the h2d transfer is complete
-    CUBE_ASYNC_KERNEL_CALL(shared2x2float2, dimGrid, dimBlock, 0, streams[1], 
+    CUBE_ASYNC_KERNEL_CALL(shared2x2, dimGrid, dimBlock, 0, streams[1], 
 			   matrix_real_d, matrix_imag_d, NSTATION, writeMatrix);
     cudaEventRecord(kernelCompletion[(p+1)%2], streams[1]); // record the completion of the kernel
     checkCudaError();
@@ -909,13 +618,17 @@ int xgpuCudaXengine(XGPUContext *context, int syncOp)
   array_compute = array_d[(PIPE_LENGTH+1)%2];
   // Final kernel calculation
 #if TEXTURE_DIM == 2
-  cudaBindTexture2D(0, tex2dfloat2, array_compute, channelDesc, NFREQUENCY*NSTATION*NPOL, NTIME_PIPE, 
-		    NFREQUENCY*NSTATION*NPOL*sizeof(ComplexInput));
+    cudaBindTexture2D(0, tex2dfloat2, array_compute, channelDesc, NFREQUENCY*NSTATION*NPOL, NTIME_PIPE, 
+		      NFREQUENCY*NSTATION*NPOL*sizeof(ComplexInput));
 #else
+#ifndef DP4A
     cudaBindTexture(0, tex1dfloat2, array_compute, channelDesc, NFREQUENCY*NSTATION*NPOL*NTIME_PIPE*sizeof(ComplexInput));
+#else
+    cudaBindTexture(0, tex1dchar4, array_compute, channelDesc, NFREQUENCY*NSTATION*NPOL*2*NTIME_PIPE*sizeof(char4)/4);
+#endif
 #endif
   cudaStreamWaitEvent(streams[1], copyCompletion[(PIPE_LENGTH+1)%2], 0);
-  CUBE_ASYNC_KERNEL_CALL(shared2x2float2, dimGrid, dimBlock, 0, streams[1], matrix_real_d, matrix_imag_d,
+  CUBE_ASYNC_KERNEL_CALL(shared2x2, dimGrid, dimBlock, 0, streams[1], matrix_real_d, matrix_imag_d,
 			 NSTATION, writeMatrix);
 
   if(syncOp == SYNCOP_DUMP) {

--- a/src/kernel.cuh
+++ b/src/kernel.cuh
@@ -442,34 +442,34 @@ CUBE_KERNEL(static shared2x2, int4 *matrix_real, int4 *matrix_imag, const int Ns
   //declare shared memory for input coalescing
 
 #if SHARED_ATOMIC_SIZE == 4
-  __shared__ char4 input[BUFFER_DEPTH][16*TILE_WIDTH]; // 16 = complex * pol * 2x2 tile size
-  char4 *input0_p = input[0] + tid;
-  char4 *input1_p = input[1] + tid;
+  __shared__ int input[BUFFER_DEPTH][16*TILE_WIDTH]; // 16 = complex * pol * 2x2 tile size
+  int *input0_p = input[0] + tid;
+  int *input1_p = input[1] + tid;
 #if BUFFER_DEPTH == 4
-  char4 *input2_p = input[2] + tid;
-  char4 *input3_p = input[3] + tid;
+  int *input2_p = input[2] + tid;
+  int *input3_p = input[3] + tid;
 #endif // BUFFER_DEPTH==4
 #else
 #error SHARED_ATOMIC_SIZE == 8 not supported for dp4a 
 #endif
 
   //instantiate sum variables
-  int sum11XXreal = 0, sum11XXimag = 0;
-  int sum11XYreal = 0, sum11XYimag = 0;
-  int sum11YXreal = 0, sum11YXimag = 0;
-  int sum11YYreal = 0, sum11YYimag = 0;
-  int sum12XXreal = 0, sum12XXimag = 0;
-  int sum12XYreal = 0, sum12XYimag = 0;
-  int sum12YXreal = 0, sum12YXimag = 0;
-  int sum12YYreal = 0, sum12YYimag = 0;
-  int sum21XXreal = 0, sum21XXimag = 0;
-  int sum21XYreal = 0, sum21XYimag = 0;
-  int sum21YXreal = 0, sum21YXimag = 0;
-  int sum21YYreal = 0, sum21YYimag = 0;
-  int sum22XXreal = 0, sum22XXimag = 0;
-  int sum22XYreal = 0, sum22XYimag = 0;
-  int sum22YXreal = 0, sum22YXimag = 0;
-  int sum22YYreal = 0, sum22YYimag = 0;
+  int sum11XXreal = 0, sum11XXimag1 = 0, sum11XXimag2 = 0;
+  int sum11XYreal = 0, sum11XYimag1 = 0, sum11XYimag2 = 0;
+  int sum11YXreal = 0, sum11YXimag1 = 0, sum11YXimag2 = 0;
+  int sum11YYreal = 0, sum11YYimag1 = 0, sum11YYimag2 = 0;
+  int sum12XXreal = 0, sum12XXimag1 = 0, sum12XXimag2 = 0;
+  int sum12XYreal = 0, sum12XYimag1 = 0, sum12XYimag2 = 0;
+  int sum12YXreal = 0, sum12YXimag1 = 0, sum12YXimag2 = 0;
+  int sum12YYreal = 0, sum12YYimag1 = 0, sum12YYimag2 = 0;
+  int sum21XXreal = 0, sum21XXimag1 = 0, sum21XXimag2 = 0;
+  int sum21XYreal = 0, sum21XYimag1 = 0, sum21XYimag2 = 0;
+  int sum21YXreal = 0, sum21YXimag1 = 0, sum21YXimag2 = 0;
+  int sum21YYreal = 0, sum21YYimag1 = 0, sum21YYimag2 = 0;
+  int sum22XXreal = 0, sum22XXimag1 = 0, sum22XXimag2 = 0;
+  int sum22XYreal = 0, sum22XYimag1 = 0, sum22XYimag2 = 0;
+  int sum22YXreal = 0, sum22YXimag1 = 0, sum22YXimag2 = 0;
+  int sum22YYreal = 0, sum22YYimag1 = 0, sum22YYimag2 = 0;
 
 #if SHARED_ATOMIC_SIZE == 8
 #if COMPLEX_BLOCK_SIZE != 1
@@ -564,14 +564,14 @@ CUBE_KERNEL(static shared2x2, int4 *matrix_real, int4 *matrix_imag, const int Ns
   if (write) {
 #endif
     CUBE_DEVICE_CALL(write2x2, Col, Row, matrix_real, matrix_imag,
-		     sum11XXreal, sum11XXimag, sum11XYreal, sum11XYimag, 
-		     sum11YXreal, sum11YXimag, sum11YYreal, sum11YYimag, 
-		     sum12XXreal, sum12XXimag, sum12XYreal, sum12XYimag, 
-		     sum12YXreal, sum12YXimag, sum12YYreal, sum12YYimag, 
-		     sum21XXreal, sum21XXimag, sum21XYreal, sum21XYimag, 
-		     sum21YXreal, sum21YXimag, sum21YYreal, sum21YYimag, 
-		     sum22XXreal, sum22XXimag, sum22XYreal, sum22XYimag, 
-		     sum22YXreal, sum22YXimag, sum22YYreal, sum22YYimag);
+		     sum11XXreal, sum11XXimag1-sum11XXimag2, sum11XYreal, sum11XYimag1-sum11XYimag2,
+		     sum11YXreal, sum11YXimag1-sum11YXimag2, sum11YYreal, sum11YYimag1-sum11YYimag2,
+		     sum12XXreal, sum12XXimag1-sum12XXimag2, sum12XYreal, sum12XYimag1-sum12XYimag2,
+		     sum12YXreal, sum12YXimag1-sum12YXimag2, sum12YYreal, sum12YYimag1-sum12YYimag2,
+		     sum21XXreal, sum21XXimag1-sum21XXimag2, sum21XYreal, sum21XYimag1-sum21XYimag2,
+		     sum21YXreal, sum21YXimag1-sum21YXimag2, sum21YYreal, sum21YYimag1-sum21YYimag2,
+		     sum22XXreal, sum22XXimag1-sum22XXimag2, sum22XYreal, sum22XYimag1-sum22XYimag2,
+		     sum22YXreal, sum22YXimag1-sum22YXimag2, sum22YYreal, sum22YYimag1-sum22YYimag2);
 
     CUBE_ADD_BYTES(Col < Row ? 256 : 192); // need load and save
 #ifdef WRITE_OPTION

--- a/src/kernel.cuh
+++ b/src/kernel.cuh
@@ -1,0 +1,590 @@
+//determine row and column from blockIdx.x
+CUBE_DEVICE(static void, findPosition, unsigned int &Col, unsigned int &Row, unsigned int &blockX, unsigned int &blockY) {
+  unsigned int k = blockIdx.x;
+#if NSTATION >= 512
+  blockY = -0.5 + sqrt(0.25 + 2*k);
+#else
+  blockY = -0.5f + sqrtf(0.25f + 2*k);
+#endif  
+  blockX = k - (((blockY+1)*(blockY)) >> 1);
+  Row = (blockY*TILE_HEIGHT + threadIdx.y);
+  Col = (blockX*TILE_WIDTH + threadIdx.x);
+}
+
+template<typename T>
+__device__ static void operator+=( T &a, const T b ) {
+ T t = a;
+ t.x += b.x; t.y += b.y; t.z += b.z; t.w += b.w;
+ a = t;
+}
+
+#ifndef DP4A
+// device function to write out the matrix elements
+CUBE_DEVICE(static void, write2x2, unsigned int &Col, unsigned int &Row, float4 *matrix_real, float4 *matrix_imag, 
+	    float sum11XXreal, float sum11XXimag, float sum11XYreal, float sum11XYimag,
+	    float sum11YXreal, float sum11YXimag, float sum11YYreal, float sum11YYimag,
+	    float sum12XXreal, float sum12XXimag, float sum12XYreal, float sum12XYimag,
+	    float sum12YXreal, float sum12YXimag, float sum12YYreal, float sum12YYimag,
+	    float sum21XXreal, float sum21XXimag, float sum21XYreal, float sum21XYimag,
+	    float sum21YXreal, float sum21YXimag, float sum21YYreal, float sum21YYimag,
+	    float sum22XXreal, float sum22XXimag, float sum22XYreal, float sum22XYimag,
+	    float sum22YXreal, float sum22YXimag, float sum22YYreal, float sum22YYimag) {
+  
+  int f=blockIdx.y;
+
+  // Set scale factor
+#ifndef FIXED_POINT
+#define SCALE 1.0f // no rescale required for FP32
+#else
+#define SCALE 16129.0f // need to rescale result 
+#endif // FIXED_POINT
+
+#if (MATRIX_ORDER == REGISTER_TILE_TRIANGULAR_ORDER) // write out the register tiles separately
+  matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*0 + (Row*(Row+1)/2) + Col] += 
+    make_float4(SCALE*sum11XXreal, SCALE*sum11XYreal, SCALE*sum11YXreal, SCALE*sum11YYreal);
+  matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*0 + (Row*(Row+1)/2) + Col] += 
+    make_float4(SCALE*sum11XXimag, SCALE*sum11XYimag, SCALE*sum11YXimag, SCALE*sum11YYimag);
+
+  matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*1 + (Row*(Row+1)/2) + Col] += 
+    make_float4(SCALE*sum21XXreal, SCALE*sum21XYreal, SCALE*sum21YXreal, SCALE*sum21YYreal);
+  matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*1 + (Row*(Row+1)/2) + Col] += 
+    make_float4(SCALE*sum21XXimag, SCALE*sum21XYimag, SCALE*sum21YXimag, SCALE*sum21YYimag);
+
+  matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*3 + (Row*(Row+1)/2) + Col] += 
+    make_float4(SCALE*sum22XXreal, SCALE*sum22XYreal, SCALE*sum22YXreal, SCALE*sum22YYreal);
+  matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*3 + (Row*(Row+1)/2) + Col] += 
+    make_float4(SCALE*sum22XXimag, SCALE*sum22XYimag, SCALE*sum22YXimag, SCALE*sum22YYimag);
+  
+  // Test if entire tile needs to be written or just 3 of 4 parts (exclude top-right)
+  if (Col<Row) {
+    matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*2 + (Row*(Row+1)/2) + Col] += 
+      make_float4(SCALE*sum12XXreal, SCALE*sum12XYreal, SCALE*sum12YXreal, SCALE*sum12YYreal);
+    matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*2 + (Row*(Row+1)/2) + Col] += 
+      make_float4(SCALE*sum12XXimag, SCALE*sum12XYimag, SCALE*sum12YXimag, SCALE*sum12YYimag);
+  }
+#elif (MATRIX_ORDER == REAL_IMAG_TRIANGULAR_ORDER) // write out the real and imaginary components separately
+  Col*=2; Row*=2;
+  matrix_real[f*NBASELINE + (Row*(Row+1)/2) + Col] += 
+    make_float4(SCALE*sum11XXreal, SCALE*sum11XYreal, SCALE*sum11YXreal, SCALE*sum11YYreal);
+  matrix_imag[f*NBASELINE + (Row*(Row+1)/2) + Col] += 
+    make_float4(SCALE*sum11XXimag, SCALE*sum11XYimag, SCALE*sum11YXimag, SCALE*sum11YYimag);
+
+  matrix_real[f*NBASELINE + ((Row+1)*(Row+2)/2) + Col] += 
+    make_float4(SCALE*sum21XXreal, SCALE*sum21XYreal, SCALE*sum21YXreal, SCALE*sum21YYreal);
+  matrix_imag[f*NBASELINE + ((Row+1)*(Row+2)/2) + Col] += 
+    make_float4(SCALE*sum21XXimag, SCALE*sum21XYimag, SCALE*sum21YXimag, SCALE*sum21YYimag);
+
+  matrix_real[f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1)] += 
+    make_float4(SCALE*sum22XXreal, SCALE*sum22XYreal, SCALE*sum22YXreal, SCALE*sum22YYreal);
+  matrix_imag[f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1)] += 
+    make_float4(SCALE*sum22XXimag, SCALE*sum22XYimag, SCALE*sum22YXimag, SCALE*sum22YYimag);
+  
+  // Test if entire tile needs to be written or just 3 of 4 parts (exclude top-right)
+  if (Col<Row) {
+    matrix_real[f*NBASELINE + (Row*(Row+1)/2) + (Col+1)] += 
+      make_float4(SCALE*sum12XXreal, SCALE*sum12XYreal, SCALE*sum12YXreal, SCALE*sum12YYreal);
+    matrix_imag[f*NBASELINE + (Row*(Row+1)/2) + (Col+1)] += 
+      make_float4(SCALE*sum12XXimag, SCALE*sum12XYimag, SCALE*sum12YXimag, SCALE*sum12YYimag);
+  }
+#else  // standard triangular packed order
+  Col*=2; Row*=2;
+  matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + Col)*NPOL + 0] += 
+    make_float4(SCALE*sum11XXreal, SCALE*sum11XXimag, SCALE*sum11XYreal, SCALE*sum11XYimag);
+  matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + Col)*NPOL + 1] += 
+    make_float4(SCALE*sum11YXreal, SCALE*sum11YXimag, SCALE*sum11YYreal, SCALE*sum11YYimag);
+  matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + Col)*NPOL + 0] += 
+    make_float4(SCALE*sum21XXreal, SCALE*sum21XXimag, SCALE*sum21XYreal, SCALE*sum21XYimag);
+  matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + Col)*NPOL + 1] += 
+    make_float4(SCALE*sum21YXreal, SCALE*sum21YXimag, SCALE*sum21YYreal, SCALE*sum21YYimag);
+  matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1))*NPOL + 0] += 
+    make_float4(SCALE*sum22XXreal, SCALE*sum22XXimag, SCALE*sum22XYreal, SCALE*sum22XYimag);
+  matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1))*NPOL + 1] += 
+    make_float4(SCALE*sum22YXreal, SCALE*sum22YXimag, SCALE*sum22YYreal, SCALE*sum22YYimag);
+  
+  // Test if entire tile needs to be written or just 3 of 4 parts (exclude top-right)
+  if (Col<Row) {
+    matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + (Col+1))*NPOL + 0] += 
+      make_float4(SCALE*sum12XXreal, SCALE*sum12XXimag, SCALE*sum12XYreal, SCALE*sum12XYimag);
+    matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + (Col+1))*NPOL + 1] += 
+      make_float4(SCALE*sum12YXreal, SCALE*sum12YXimag, SCALE*sum12YYreal, SCALE*sum12YYimag);
+  }
+#endif
+
+}
+
+#else
+
+// device function to write out the matrix elements
+CUBE_DEVICE(static void, write2x2, unsigned int &Col, unsigned int &Row, int4 *matrix_real, int4 *matrix_imag, 
+	    int sum11XXreal, int sum11XXimag, int sum11XYreal, int sum11XYimag,
+	    int sum11YXreal, int sum11YXimag, int sum11YYreal, int sum11YYimag,
+	    int sum12XXreal, int sum12XXimag, int sum12XYreal, int sum12XYimag,
+	    int sum12YXreal, int sum12YXimag, int sum12YYreal, int sum12YYimag,
+	    int sum21XXreal, int sum21XXimag, int sum21XYreal, int sum21XYimag,
+	    int sum21YXreal, int sum21YXimag, int sum21YYreal, int sum21YYimag,
+	    int sum22XXreal, int sum22XXimag, int sum22XYreal, int sum22XYimag,
+	    int sum22YXreal, int sum22YXimag, int sum22YYreal, int sum22YYimag) {
+  
+  int f=blockIdx.y;
+
+#if (MATRIX_ORDER == REGISTER_TILE_TRIANGULAR_ORDER) // write out the register tiles separately
+  matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*0 + (Row*(Row+1)/2) + Col] += 
+    make_int4(sum11XXreal, sum11XYreal, sum11YXreal, sum11YYreal);
+  matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*0 + (Row*(Row+1)/2) + Col] += 
+    make_int4(sum11XXimag, sum11XYimag, sum11YXimag, sum11YYimag);
+
+  matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*1 + (Row*(Row+1)/2) + Col] += 
+    make_int4(sum21XXreal, sum21XYreal, sum21YXreal, sum21YYreal);
+  matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*1 + (Row*(Row+1)/2) + Col] += 
+    make_int4(sum21XXimag, sum21XYimag, sum21YXimag, sum21YYimag);
+
+  matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*3 + (Row*(Row+1)/2) + Col] += 
+    make_int4(sum22XXreal, sum22XYreal, sum22YXreal, sum22YYreal);
+  matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*3 + (Row*(Row+1)/2) + Col] += 
+    make_int4(sum22XXimag, sum22XYimag, sum22YXimag, sum22YYimag);
+  
+  // Test if entire tile needs to be written or just 3 of 4 parts (exclude top-right)
+  if (Col<Row) {
+    matrix_real[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*2 + (Row*(Row+1)/2) + Col] += 
+      make_int4(sum12XXreal, sum12XYreal, sum12YXreal, sum12YYreal);
+    matrix_imag[f*4*REG_TILE_NBASELINE + REG_TILE_NBASELINE*2 + (Row*(Row+1)/2) + Col] += 
+      make_int4(sum12XXimag, sum12XYimag, sum12YXimag, sum12YYimag);
+  }
+#elif (MATRIX_ORDER == REAL_IMAG_TRIANGULAR_ORDER) // write out the real and imaginary components separately
+  Col*=2; Row*=2;
+  matrix_real[f*NBASELINE + (Row*(Row+1)/2) + Col] += 
+    make_int4(sum11XXreal, sum11XYreal, sum11YXreal, sum11YYreal);
+  matrix_imag[f*NBASELINE + (Row*(Row+1)/2) + Col] += 
+    make_int4(sum11XXimag, sum11XYimag, sum11YXimag, sum11YYimag);
+
+  matrix_real[f*NBASELINE + ((Row+1)*(Row+2)/2) + Col] += 
+    make_int4(sum21XXreal, sum21XYreal, sum21YXreal, sum21YYreal);
+  matrix_imag[f*NBASELINE + ((Row+1)*(Row+2)/2) + Col] += 
+    make_int4(sum21XXimag, sum21XYimag, sum21YXimag, sum21YYimag);
+
+  matrix_real[f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1)] += 
+    make_int4(sum22XXreal, sum22XYreal, sum22YXreal, sum22YYreal);
+  matrix_imag[f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1)] += 
+    make_int4(sum22XXimag, sum22XYimag, sum22YXimag, sum22YYimag);
+  
+  // Test if entire tile needs to be written or just 3 of 4 parts (exclude top-right)
+  if (Col<Row) {
+    matrix_real[f*NBASELINE + (Row*(Row+1)/2) + (Col+1)] += 
+      make_int4(sum12XXreal, sum12XYreal, sum12YXreal, sum12YYreal);
+    matrix_imag[f*NBASELINE + (Row*(Row+1)/2) + (Col+1)] += 
+      make_int4(sum12XXimag, sum12XYimag, sum12YXimag, sum12YYimag);
+  }
+#else  // standard triangular packed order
+  Col*=2; Row*=2;
+  matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + Col)*NPOL + 0] += 
+    make_int4(sum11XXreal, sum11XXimag, sum11XYreal, sum11XYimag);
+  matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + Col)*NPOL + 1] += 
+    make_int4(sum11YXreal, sum11YXimag, sum11YYreal, sum11YYimag);
+  matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + Col)*NPOL + 0] += 
+    make_int4(sum21XXreal, sum21XXimag, sum21XYreal, sum21XYimag);
+  matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + Col)*NPOL + 1] += 
+    make_int4(sum21YXreal, sum21YXimag, sum21YYreal, sum21YYimag);
+  matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1))*NPOL + 0] += 
+    make_int4(sum22XXreal, sum22XXimag, sum22XYreal, sum22XYimag);
+  matrix_real[(f*NBASELINE + ((Row+1)*(Row+2)/2) + (Col+1))*NPOL + 1] += 
+    make_int4(sum22YXreal, sum22YXimag, sum22YYreal, sum22YYimag);
+  
+  // Test if entire tile needs to be written or just 3 of 4 parts (exclude top-right)
+  if (Col<Row) {
+    matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + (Col+1))*NPOL + 0] += 
+      make_int4(sum12XXreal, sum12XXimag, sum12XYreal, sum12XYimag);
+    matrix_real[(f*NBASELINE + (Row*(Row+1)/2) + (Col+1))*NPOL + 1] += 
+      make_int4(sum12YXreal, sum12YXimag, sum12YYreal, sum12YYimag);
+  }
+#endif
+
+}
+
+#endif
+
+#ifndef COMPLEX_BLOCK_SIZE
+#define COMPLEX_BLOCK_SIZE 1
+#endif
+
+#if COMPLEX_BLOCK_SIZE != 1 && COMPLEX_BLOCK_SIZE != 32
+#error COMPLEX_BLOCK_SIZE must be 1 or 32
+#endif
+
+//#define STRUCT_OF_ARRAY
+
+#ifdef DP4A
+#include "shared_transfer_4_dp4a.cuh"
+#else
+// Use the appropriate shared memory load / store routines according to the atomic size
+#if SHARED_ATOMIC_SIZE == 4
+#include "shared_transfer_4.cuh"
+#elif SHARED_ATOMIC_SIZE == 8
+#include "shared_transfer_8.cuh"
+#else
+#error SHARED_ATOMIC_SIZE must be 4 or 8
+#endif
+#endif
+
+
+#ifndef DP4A
+
+CUBE_KERNEL(static shared2x2, float4 *matrix_real, float4 *matrix_imag, const int Nstation, const int write)
+{
+  CUBE_START;
+
+// Set the degree of shared memory buffering to use
+#if __CUDA_ARCH__ < 300 
+#define BUFFER_DEPTH 2 // Fermi optimal setting
+#else 
+#define BUFFER_DEPTH 4 // Kepler optimal setting
+#endif
+
+  //get local thread ID
+  unsigned int ty = threadIdx.y;
+  unsigned int tx = threadIdx.x;
+  unsigned int tid = ty*TILE_WIDTH + tx;
+
+  //set frequency number from blockIdx.y
+  unsigned int f = blockIdx.y;
+
+  unsigned int Row, Col, blockX, blockY;
+  CUBE_DEVICE_CALL(findPosition, Col, Row, blockX, blockY);
+
+  //declare shared memory for input coalescing
+
+#if SHARED_ATOMIC_SIZE == 4
+  __shared__ float input[BUFFER_DEPTH][16*TILE_WIDTH]; // 4* for float4, 4* for 2x2 tile size
+  float *input0_p = input[0] + tid;
+  float *input1_p = input[1] + tid;
+#if BUFFER_DEPTH == 4
+  float *input2_p = input[2] + tid;
+  float *input3_p = input[3] + tid;
+#endif // BUFFER_DEPTH==4
+#else
+  __shared__ float2 input[BUFFER_DEPTH][8*TILE_WIDTH]; // 2* for float4/float2, 4* for 2x2 tile size
+
+#ifdef STRUCT_OF_ARRAY
+  unsigned swizzled_tid = ((tid & 0x1c) >> 1) | ((tid & 2)    << 3) | (tid & 0x21);
+  float2 *input0_p = input[0] + swizzled_tid;
+  float2 *input1_p = input[1] + swizzled_tid;
+#if BUFFER_DEPTH == 4
+  float2 *input2_p = input[2] + swizzled_tid;
+  float2 *input3_p = input[3] + swizzled_tid;
+#endif // BUFFER_DEPTH==4
+
+#else
+
+  float2 *input0_p = input[0] + tid;
+  float2 *input1_p = input[1] + tid;
+#if BUFFER_DEPTH == 4
+  float2 *input2_p = input[2] + tid;
+  float2 *input3_p = input[3] + tid;
+#endif // BUFFER_DEPTH==4
+#endif // STRUCT_OF_ARRAY
+
+#endif
+
+  //instantiate sum variables
+  float sum11XXreal = 0.0, sum11XXimag = 0.0;
+  float sum11XYreal = 0.0, sum11XYimag = 0.0;
+  float sum11YXreal = 0.0, sum11YXimag = 0.0;
+  float sum11YYreal = 0.0, sum11YYimag = 0.0;
+  float sum12XXreal = 0.0, sum12XXimag = 0.0;
+  float sum12XYreal = 0.0, sum12XYimag = 0.0;
+  float sum12YXreal = 0.0, sum12YXimag = 0.0;
+  float sum12YYreal = 0.0, sum12YYimag = 0.0;
+  float sum21XXreal = 0.0, sum21XXimag = 0.0;
+  float sum21XYreal = 0.0, sum21XYimag = 0.0;
+  float sum21YXreal = 0.0, sum21YXimag = 0.0;
+  float sum21YYreal = 0.0, sum21YYimag = 0.0;
+  float sum22XXreal = 0.0, sum22XXimag = 0.0;
+  float sum22XYreal = 0.0, sum22XYimag = 0.0;
+  float sum22YXreal = 0.0, sum22YXimag = 0.0;
+  float sum22YYreal = 0.0, sum22YYimag = 0.0;
+
+#if SHARED_ATOMIC_SIZE == 8
+#if COMPLEX_BLOCK_SIZE != 1
+#error COMPLEX_BLOCK_SIZE must be 1 for SHARED_ATOMIC_SIZE == 8 (for now)
+#endif
+#endif
+
+  unsigned int array_index = f*Nstation*NPOL + tid;
+
+  if (tid < 4*TILE_WIDTH) {
+    // Read in column in first warp
+    array_index += 2*blockX*TILE_WIDTH*NPOL;
+  } else {
+    // Read in row in second warp
+    array_index += 2*blockY*TILE_WIDTH*NPOL - 4*TILE_HEIGHT;    
+#if SHARED_ATOMIC_SIZE == 4
+    // threads 32..63 now have offset 64..95
+    input0_p += 4*TILE_WIDTH;
+    input1_p += 4*TILE_WIDTH;
+#if BUFFER_DEPTH==4
+    input2_p += 4*TILE_WIDTH;
+    input3_p += 4*TILE_WIDTH;
+#endif // BUFFER_DEPTH=4
+#endif
+  }
+
+#if BUFFER_DEPTH==2
+  LOAD(0, 0);
+#elif BUFFER_DEPTH==4
+  LOAD(0, 0);
+  LOAD(1, 1);
+#endif
+
+#if __CUDA_ARCH__ < 300
+#pragma unroll 2
+#else
+#pragma unroll 1
+#endif
+  for(unsigned int t=0; t<NTIME_PIPE-BUFFER_DEPTH; t+=BUFFER_DEPTH){
+
+    __syncthreads();
+
+#if BUFFER_DEPTH==2
+    TWO_BY_TWO_COMPUTE(0);
+    LOAD(1, t+1);
+#elif BUFFER_DEPTH==4
+    TWO_BY_TWO_COMPUTE(0);
+    TWO_BY_TWO_COMPUTE(1);
+    LOAD(2, t+2);
+    LOAD(3, t+3);
+#endif
+
+    __syncthreads();
+
+
+#if BUFFER_DEPTH==2
+    TWO_BY_TWO_COMPUTE(1);
+    LOAD(0, t+2);
+#elif BUFFER_DEPTH==4
+    TWO_BY_TWO_COMPUTE(2);
+    TWO_BY_TWO_COMPUTE(3);
+    LOAD(0, t+4);
+    LOAD(1, t+5);
+#endif
+
+  } 
+
+  __syncthreads();  
+
+#if BUFFER_DEPTH==2
+  TWO_BY_TWO_COMPUTE(0);
+  LOAD(1, NTIME_PIPE-1);
+#elif BUFFER_DEPTH==4
+  TWO_BY_TWO_COMPUTE(0);
+  TWO_BY_TWO_COMPUTE(1);
+  LOAD(2, NTIME_PIPE-2);
+  LOAD(3, NTIME_PIPE-1);
+#endif
+
+  __syncthreads();
+
+#if BUFFER_DEPTH==2
+  TWO_BY_TWO_COMPUTE(1);
+#elif BUFFER_DEPTH==4
+  TWO_BY_TWO_COMPUTE(2);
+  TWO_BY_TWO_COMPUTE(3);
+#endif
+
+  if (Col > Row) return; // writes seem faster when this is pulled up here
+
+#ifdef WRITE_OPTION
+  if (write) {
+#endif
+    CUBE_DEVICE_CALL(write2x2, Col, Row, matrix_real, matrix_imag,
+		     sum11XXreal, sum11XXimag, sum11XYreal, sum11XYimag, 
+		     sum11YXreal, sum11YXimag, sum11YYreal, sum11YYimag, 
+		     sum12XXreal, sum12XXimag, sum12XYreal, sum12XYimag, 
+		     sum12YXreal, sum12YXimag, sum12YYreal, sum12YYimag, 
+		     sum21XXreal, sum21XXimag, sum21XYreal, sum21XYimag, 
+		     sum21YXreal, sum21YXimag, sum21YYreal, sum21YYimag, 
+		     sum22XXreal, sum22XXimag, sum22XYreal, sum22XYimag, 
+		     sum22YXreal, sum22YXimag, sum22YYreal, sum22YYimag);
+
+    CUBE_ADD_BYTES(Col < Row ? 256 : 192); // need load and save
+#ifdef WRITE_OPTION
+  }
+#endif
+
+  CUBE_ADD_FLOPS(NTIME_PIPE*(Col < Row ? 128 : 96));
+
+  CUBE_END;
+}
+
+
+#else // doing DP4A computation
+
+CUBE_KERNEL(static shared2x2, int4 *matrix_real, int4 *matrix_imag, const int Nstation, const int write)
+{
+  CUBE_START;
+
+// Set the degree of shared memory buffering to use
+#if __CUDA_ARCH__ < 300 
+#define BUFFER_DEPTH 2 // Fermi optimal setting
+#else 
+#define BUFFER_DEPTH 4 // Kepler optimal setting
+#endif
+
+  //get local thread ID
+  unsigned int ty = threadIdx.y;
+  unsigned int tx = threadIdx.x;
+  unsigned int tid = ty*TILE_WIDTH + tx;
+
+  //set frequency number from blockIdx.y
+  unsigned int f = blockIdx.y;
+
+  unsigned int Row, Col, blockX, blockY;
+  CUBE_DEVICE_CALL(findPosition, Col, Row, blockX, blockY);
+
+  //declare shared memory for input coalescing
+
+#if SHARED_ATOMIC_SIZE == 4
+  __shared__ char4 input[BUFFER_DEPTH][16*TILE_WIDTH]; // 16 = complex * pol * 2x2 tile size
+  char4 *input0_p = input[0] + tid;
+  char4 *input1_p = input[1] + tid;
+#if BUFFER_DEPTH == 4
+  char4 *input2_p = input[2] + tid;
+  char4 *input3_p = input[3] + tid;
+#endif // BUFFER_DEPTH==4
+#else
+#error SHARED_ATOMIC_SIZE == 8 not supported for dp4a 
+#endif
+
+  //instantiate sum variables
+  int sum11XXreal = 0, sum11XXimag = 0;
+  int sum11XYreal = 0, sum11XYimag = 0;
+  int sum11YXreal = 0, sum11YXimag = 0;
+  int sum11YYreal = 0, sum11YYimag = 0;
+  int sum12XXreal = 0, sum12XXimag = 0;
+  int sum12XYreal = 0, sum12XYimag = 0;
+  int sum12YXreal = 0, sum12YXimag = 0;
+  int sum12YYreal = 0, sum12YYimag = 0;
+  int sum21XXreal = 0, sum21XXimag = 0;
+  int sum21XYreal = 0, sum21XYimag = 0;
+  int sum21YXreal = 0, sum21YXimag = 0;
+  int sum21YYreal = 0, sum21YYimag = 0;
+  int sum22XXreal = 0, sum22XXimag = 0;
+  int sum22XYreal = 0, sum22XYimag = 0;
+  int sum22YXreal = 0, sum22YXimag = 0;
+  int sum22YYreal = 0, sum22YYimag = 0;
+
+#if SHARED_ATOMIC_SIZE == 8
+#if COMPLEX_BLOCK_SIZE != 1
+#error COMPLEX_BLOCK_SIZE must be 1 for SHARED_ATOMIC_SIZE == 8 (for now)
+#endif
+#endif
+
+  unsigned int array_index = f*Nstation*NPOL + tid;
+
+  if (tid < 4*TILE_WIDTH) {
+    // Read in column in first warp
+    array_index += 2*blockX*TILE_WIDTH*NPOL;
+  } else {
+    // Read in row in second warp
+    array_index += 2*blockY*TILE_WIDTH*NPOL - 4*TILE_HEIGHT;    
+#if SHARED_ATOMIC_SIZE == 4
+    // threads 32..63 now have offset 64..95
+    input0_p += 4*TILE_WIDTH;
+    input1_p += 4*TILE_WIDTH;
+#if BUFFER_DEPTH==4
+    input2_p += 4*TILE_WIDTH;
+    input3_p += 4*TILE_WIDTH;
+#endif // BUFFER_DEPTH=4
+#endif
+  }
+
+#if BUFFER_DEPTH==2
+  LOAD(0, 0);
+#elif BUFFER_DEPTH==4
+  LOAD(0, 0);
+  LOAD(1, 1);
+#endif
+
+#if __CUDA_ARCH__ < 300
+#pragma unroll 2
+#else
+#pragma unroll 1
+#endif
+  for(unsigned int t=0; t<NTIME_PIPE/4-BUFFER_DEPTH; t+=BUFFER_DEPTH){
+
+    __syncthreads();
+
+#if BUFFER_DEPTH==2
+    TWO_BY_TWO_COMPUTE(0);
+    LOAD(1, t+1);
+#elif BUFFER_DEPTH==4
+    TWO_BY_TWO_COMPUTE(0);
+    TWO_BY_TWO_COMPUTE(1);
+    LOAD(2, t+2);
+    LOAD(3, t+3);
+#endif
+
+    __syncthreads();
+
+
+#if BUFFER_DEPTH==2
+    TWO_BY_TWO_COMPUTE(1);
+    LOAD(0, t+2);
+#elif BUFFER_DEPTH==4
+    TWO_BY_TWO_COMPUTE(2);
+    TWO_BY_TWO_COMPUTE(3);
+    LOAD(0, t+4);
+    LOAD(1, t+5);
+#endif
+
+  } 
+
+  __syncthreads();  
+
+#if BUFFER_DEPTH==2
+  TWO_BY_TWO_COMPUTE(0);
+  LOAD(1, NTIME_PIPE/4-1);
+#elif BUFFER_DEPTH==4
+  TWO_BY_TWO_COMPUTE(0);
+  TWO_BY_TWO_COMPUTE(1);
+  LOAD(2, NTIME_PIPE/4-2);
+  LOAD(3, NTIME_PIPE/4-1);
+#endif
+
+  __syncthreads();
+
+#if BUFFER_DEPTH==2
+  TWO_BY_TWO_COMPUTE(1);
+#elif BUFFER_DEPTH==4
+  TWO_BY_TWO_COMPUTE(2);
+  TWO_BY_TWO_COMPUTE(3);
+#endif
+
+  if (Col > Row) return; // writes seem faster when this is pulled up here
+
+#ifdef WRITE_OPTION
+  if (write) {
+#endif
+    CUBE_DEVICE_CALL(write2x2, Col, Row, matrix_real, matrix_imag,
+		     sum11XXreal, sum11XXimag, sum11XYreal, sum11XYimag, 
+		     sum11YXreal, sum11YXimag, sum11YYreal, sum11YYimag, 
+		     sum12XXreal, sum12XXimag, sum12XYreal, sum12XYimag, 
+		     sum12YXreal, sum12YXimag, sum12YYreal, sum12YYimag, 
+		     sum21XXreal, sum21XXimag, sum21XYreal, sum21XYimag, 
+		     sum21YXreal, sum21YXimag, sum21YYreal, sum21YYimag, 
+		     sum22XXreal, sum22XXimag, sum22XYreal, sum22XYimag, 
+		     sum22YXreal, sum22YXimag, sum22YYreal, sum22YYimag);
+
+    CUBE_ADD_BYTES(Col < Row ? 256 : 192); // need load and save
+#ifdef WRITE_OPTION
+  }
+#endif
+
+  CUBE_ADD_FLOPS(NTIME_PIPE*(Col < Row ? 128 : 96));
+
+  CUBE_END;
+}
+
+#endif
+
+// cleanup macro definitions
+#undef LOAD
+#undef TWO_BY_TWO_COMPUTE

--- a/src/shared_transfer_4_dp4a.cuh
+++ b/src/shared_transfer_4_dp4a.cuh
@@ -1,0 +1,154 @@
+// Define TEXTURE_DIM as 1 to use 1D texture (more accurate, costs 1 mult per LOAD)
+// Define TEXTURE_DIM as 2 to use 2D texture (less accurate, saves 1 mult per LOAD)
+#ifndef TEXTURE_DIM
+#define TEXTURE_DIM 1
+#endif
+
+#if TEXTURE_DIM == 1
+
+// Read char4 from global, write char4s to shared memory avoid bank conflict.
+#define LOAD(s, t)							\
+  {char4 real = tex1Dfetch(tex1dchar4, array_index + (t)*NFREQUENCY*NSTATION*NPOL); \
+    char4 imag = tex1Dfetch(tex1dchar4, array_index + (NTIME_PIPE/4 + t)*NFREQUENCY*NSTATION*NPOL); \
+    CUBE_ADD_BYTES(sizeof(ComplexInput));				\
+    *(input##s##_p) = real;						\
+    *(input##s##_p + 4*TILE_WIDTH) = imag;}
+
+#else
+#error TEXTURE_DIM must be 1
+#endif
+
+// read in shared data as individual floats to avoid bank conflicts
+
+#if COMPLEX_BLOCK_SIZE == 1
+#define TWO_BY_TWO_PRELOAD(s)						\
+ {char4 col1Xreal = input[s][4*tx                                   ];	\
+  char4 col1Ximag = input[s][4*tx     + 4*TILE_WIDTH                ];	\
+  char4 col1Yreal = input[s][4*tx + 1                               ];	\
+  char4 col1Yimag = input[s][4*tx + 1 + 4*TILE_WIDTH                ];	\
+  char4 col2Xreal = input[s][4*tx + 2                               ];	\
+  char4 col2Ximag = input[s][4*tx + 2 + 4*TILE_WIDTH                ];	\
+  char4 col2Yreal = input[s][4*tx + 3                               ];	\
+  char4 col2Yimag = input[s][4*tx + 3 + 4*TILE_WIDTH                ];	\
+  char4 row1Xreal = input[s][4*ty                     + 8*TILE_WIDTH];	\
+  char4 row1Ximag = input[s][4*ty     + 4*TILE_HEIGHT + 8*TILE_WIDTH];	\
+  char4 row1Yreal = input[s][4*ty + 1                 + 8*TILE_WIDTH];	\
+  char4 row1Yimag = input[s][4*ty + 1 + 4*TILE_HEIGHT + 8*TILE_WIDTH];	\
+  char4 row2Xreal = input[s][4*ty + 2                 + 8*TILE_WIDTH];	\
+  char4 row2Ximag = input[s][4*ty + 2 + 4*TILE_HEIGHT + 8*TILE_WIDTH];	\
+  char4 row2Yreal = input[s][4*ty + 3                 + 8*TILE_WIDTH];	\
+  char4 row2Yimag = input[s][4*ty + 3 + 4*TILE_HEIGHT + 8*TILE_WIDTH];
+#elif COMPLEX_BLOCK_SIZE == 32
+#define TWO_BY_TWO_PRELOAD(s)						\
+ {char4 col1Xreal = input[s][2*tx                                  ];	\
+  char4 col1Ximag = input[s][2*tx     + 2*TILE_WIDTH               ];	\
+  char4 col1Yreal = input[s][2*tx     + 4*TILE_WIDTH               ];	\
+  char4 col1Yimag = input[s][2*tx     + 6*TILE_WIDTH               ];	\
+  char4 col2Xreal = input[s][2*tx + 1                              ];	\
+  char4 col2Yreal = input[s][2*tx + 1 + 4*TILE_WIDTH               ];	\
+  char4 col2Ximag = input[s][2*tx + 1 + 2*TILE_WIDTH               ];	\
+  char4 col2Yimag = input[s][2*tx + 1 + 6*TILE_WIDTH               ];	\
+  char4 row1Xreal = input[s][2*ty                    + 8*TILE_WIDTH];	\
+  char4 row1Ximag = input[s][2*ty     + 2*TILE_WIDTH + 8*TILE_WIDTH];	\
+  char4 row1Yreal = input[s][2*ty     + 4*TILE_WIDTH + 8*TILE_WIDTH];	\
+  char4 row1Yimag = input[s][2*ty     + 6*TILE_WIDTH + 8*TILE_WIDTH];	\
+  char4 row2Xreal = input[s][2*ty + 1                + 8*TILE_WIDTH];	\
+  char4 row2Yreal = input[s][2*ty + 1 + 4*TILE_WIDTH + 8*TILE_WIDTH];	\
+  char4 row2Ximag = input[s][2*ty + 1 + 2*TILE_WIDTH + 8*TILE_WIDTH];	\
+  char4 row2Yimag = input[s][2*ty + 1 + 6*TILE_WIDTH + 8*TILE_WIDTH];
+#else
+#error COMPLEX_BLOCK_SIZE must be 1 or 32
+#endif // COMPLEX_BLOCK_SIZE
+
+inline __device__ void dp4a(int &c, const char4 &a, const char4 &b) {
+#if __CUDA_ARCH__ >= 610
+  int &ai = *((int*)&a);
+  int &bi = *((int*)&b);
+  asm("dp4a.s32.s32 %0, %1, %2, %0;" : "+r"(c) : "r"(ai), "r"(bi));
+#else
+  c += a.x*b.x;
+  c += a.y*b.y;
+  c += a.z*b.z;
+  c += a.w*b.w;
+#endif
+}
+
+inline __device__ void dp4s(int &c, const char4 &a, const char4 &b) {
+#if __CUDA_ARCH__ >= 610
+  int &ai = *((int*)&a);
+  int &bi = *((int*)&b);
+  asm("dp4a.s32.s32 %0, %1, %2, %3;" : "+r"(c) : "r"(ai), "r"(bi), "r"(-c));
+#else
+  c -= a.x*b.x;
+  c -= a.y*b.y;
+  c -= a.z*b.z;
+  c -= a.w*b.w;  
+#endif
+}
+
+#define TWO_BY_TWO_COMPUTE(s)						\
+  TWO_BY_TWO_PRELOAD(s)							\
+  dp4a(sum11XXreal,row1Xreal,col1Xreal);				\
+  dp4a(sum11XXreal,row1Ximag,col1Ximag);				\
+  dp4a(sum11XXimag,row1Ximag,col1Xreal);				\
+  dp4s(sum11XXimag,row1Xreal,col1Ximag);				\
+  dp4a(sum11XYreal,row1Xreal,col1Yreal);				\
+  dp4a(sum11XYreal,row1Ximag,col1Yimag);				\
+  dp4a(sum11XYimag,row1Ximag,col1Yreal);				\
+  dp4s(sum11XYimag,row1Xreal,col1Yimag);				\
+  dp4a(sum11YXreal,row1Yreal,col1Xreal);				\
+  dp4a(sum11YXreal,row1Yimag,col1Ximag);				\
+  dp4a(sum11YXimag,row1Yimag,col1Xreal);				\
+  dp4s(sum11YXimag,row1Yreal,col1Ximag);				\
+  dp4a(sum11YYreal,row1Yreal,col1Yreal);				\
+  dp4a(sum11YYreal,row1Yimag,col1Yimag);				\
+  dp4a(sum11YYimag,row1Yimag,col1Yreal);				\
+  dp4s(sum11YYimag,row1Yreal,col1Yimag);				\
+  dp4a(sum12XXreal,row1Xreal,col2Xreal);				\
+  dp4a(sum12XXreal,row1Ximag,col2Ximag);				\
+  dp4a(sum12XXimag,row1Ximag,col2Xreal);				\
+  dp4s(sum12XXimag,row1Xreal,col2Ximag);				\
+  dp4a(sum12XYreal,row1Xreal,col2Yreal);				\
+  dp4a(sum12XYreal,row1Ximag,col2Yimag);				\
+  dp4a(sum12XYimag,row1Ximag,col2Yreal);				\
+  dp4s(sum12XYimag,row1Xreal,col2Yimag);				\
+  dp4a(sum12YXreal,row1Yreal,col2Xreal);				\
+  dp4a(sum12YXreal,row1Yimag,col2Ximag);				\
+  dp4a(sum12YXimag,row1Yimag,col2Xreal);				\
+  dp4s(sum12YXimag,row1Yreal,col2Ximag);				\
+  dp4a(sum12YYreal,row1Yreal,col2Yreal);				\
+  dp4a(sum12YYreal,row1Yimag,col2Yimag);				\
+  dp4a(sum12YYimag,row1Yimag,col2Yreal);				\
+  dp4s(sum12YYimag,row1Yreal,col2Yimag);				\
+  dp4a(sum21XXreal,row2Xreal,col1Xreal);				\
+  dp4a(sum21XXreal,row2Ximag,col1Ximag);				\
+  dp4a(sum21XXimag,row2Ximag,col1Xreal);				\
+  dp4s(sum21XXimag,row2Xreal,col1Ximag);				\
+  dp4a(sum21XYreal,row2Xreal,col1Yreal);				\
+  dp4a(sum21XYreal,row2Ximag,col1Yimag);				\
+  dp4a(sum21XYimag,row2Ximag,col1Yreal);				\
+  dp4s(sum21XYimag,row2Xreal,col1Yimag);				\
+  dp4a(sum21YXreal,row2Yreal,col1Xreal);				\
+  dp4a(sum21YXreal,row2Yimag,col1Ximag);				\
+  dp4a(sum21YXimag,row2Yimag,col1Xreal);				\
+  dp4s(sum21YXimag,row2Yreal,col1Ximag);				\
+  dp4a(sum21YYreal,row2Yreal,col1Yreal);				\
+  dp4a(sum21YYreal,row2Yimag,col1Yimag);				\
+  dp4a(sum21YYimag,row2Yimag,col1Yreal);				\
+  dp4s(sum21YYimag,row2Yreal,col1Yimag);				\
+  dp4a(sum22XXreal,row2Xreal,col2Xreal);				\
+  dp4a(sum22XXreal,row2Ximag,col2Ximag);				\
+  dp4a(sum22XXimag,row2Ximag,col2Xreal);				\
+  dp4s(sum22XXimag,row2Xreal,col2Ximag);				\
+  dp4a(sum22XYreal,row2Xreal,col2Yreal);				\
+  dp4a(sum22XYreal,row2Ximag,col2Yimag);				\
+  dp4a(sum22XYimag,row2Ximag,col2Yreal);				\
+  dp4s(sum22XYimag,row2Xreal,col2Yimag);				\
+  dp4a(sum22YXreal,row2Yreal,col2Xreal);				\
+  dp4a(sum22YXreal,row2Yimag,col2Ximag);				\
+  dp4a(sum22YXimag,row2Yimag,col2Xreal);				\
+  dp4s(sum22YXimag,row2Yreal,col2Ximag);				\
+  dp4a(sum22YYreal,row2Yreal,col2Yreal);				\
+  dp4a(sum22YYreal,row2Yimag,col2Yimag);				\
+  dp4a(sum22YYimag,row2Yimag,col2Yreal);				\
+  dp4s(sum22YYimag,row2Yreal,col2Yimag);}

--- a/src/shared_transfer_4_dp4a.cuh
+++ b/src/shared_transfer_4_dp4a.cuh
@@ -11,8 +11,8 @@
   {char4 real = tex1Dfetch(tex1dchar4, array_index + (t)*NFREQUENCY*NSTATION*NPOL); \
     char4 imag = tex1Dfetch(tex1dchar4, array_index + (NTIME_PIPE/4 + t)*NFREQUENCY*NSTATION*NPOL); \
     CUBE_ADD_BYTES(sizeof(ComplexInput));				\
-    *(input##s##_p) = real;						\
-    *(input##s##_p + 4*TILE_WIDTH) = imag;}
+    *(input##s##_p) = *((int*)&real);					\
+    *(input##s##_p + 4*TILE_WIDTH) = *((int*)&imag);}
 
 #else
 #error TEXTURE_DIM must be 1
@@ -22,67 +22,54 @@
 
 #if COMPLEX_BLOCK_SIZE == 1
 #define TWO_BY_TWO_PRELOAD(s)						\
- {char4 col1Xreal = input[s][4*tx                                   ];	\
-  char4 col1Ximag = input[s][4*tx     + 4*TILE_WIDTH                ];	\
-  char4 col1Yreal = input[s][4*tx + 1                               ];	\
-  char4 col1Yimag = input[s][4*tx + 1 + 4*TILE_WIDTH                ];	\
-  char4 col2Xreal = input[s][4*tx + 2                               ];	\
-  char4 col2Ximag = input[s][4*tx + 2 + 4*TILE_WIDTH                ];	\
-  char4 col2Yreal = input[s][4*tx + 3                               ];	\
-  char4 col2Yimag = input[s][4*tx + 3 + 4*TILE_WIDTH                ];	\
-  char4 row1Xreal = input[s][4*ty                     + 8*TILE_WIDTH];	\
-  char4 row1Ximag = input[s][4*ty     + 4*TILE_HEIGHT + 8*TILE_WIDTH];	\
-  char4 row1Yreal = input[s][4*ty + 1                 + 8*TILE_WIDTH];	\
-  char4 row1Yimag = input[s][4*ty + 1 + 4*TILE_HEIGHT + 8*TILE_WIDTH];	\
-  char4 row2Xreal = input[s][4*ty + 2                 + 8*TILE_WIDTH];	\
-  char4 row2Ximag = input[s][4*ty + 2 + 4*TILE_HEIGHT + 8*TILE_WIDTH];	\
-  char4 row2Yreal = input[s][4*ty + 3                 + 8*TILE_WIDTH];	\
-  char4 row2Yimag = input[s][4*ty + 3 + 4*TILE_HEIGHT + 8*TILE_WIDTH];
+ {int col1Xreal = input[s][4*tx                                   ];	\
+  int col1Ximag = input[s][4*tx     + 4*TILE_WIDTH                ];	\
+  int col1Yreal = input[s][4*tx + 1                               ];	\
+  int col1Yimag = input[s][4*tx + 1 + 4*TILE_WIDTH                ];	\
+  int col2Xreal = input[s][4*tx + 2                               ];	\
+  int col2Ximag = input[s][4*tx + 2 + 4*TILE_WIDTH                ];	\
+  int col2Yreal = input[s][4*tx + 3                               ];	\
+  int col2Yimag = input[s][4*tx + 3 + 4*TILE_WIDTH                ];	\
+  int row1Xreal = input[s][4*ty                     + 8*TILE_WIDTH];	\
+  int row1Ximag = input[s][4*ty     + 4*TILE_HEIGHT + 8*TILE_WIDTH];	\
+  int row1Yreal = input[s][4*ty + 1                 + 8*TILE_WIDTH];	\
+  int row1Yimag = input[s][4*ty + 1 + 4*TILE_HEIGHT + 8*TILE_WIDTH];	\
+  int row2Xreal = input[s][4*ty + 2                 + 8*TILE_WIDTH];	\
+  int row2Ximag = input[s][4*ty + 2 + 4*TILE_HEIGHT + 8*TILE_WIDTH];	\
+  int row2Yreal = input[s][4*ty + 3                 + 8*TILE_WIDTH];	\
+  int row2Yimag = input[s][4*ty + 3 + 4*TILE_HEIGHT + 8*TILE_WIDTH];
 #elif COMPLEX_BLOCK_SIZE == 32
 #define TWO_BY_TWO_PRELOAD(s)						\
- {char4 col1Xreal = input[s][2*tx                                  ];	\
-  char4 col1Ximag = input[s][2*tx     + 2*TILE_WIDTH               ];	\
-  char4 col1Yreal = input[s][2*tx     + 4*TILE_WIDTH               ];	\
-  char4 col1Yimag = input[s][2*tx     + 6*TILE_WIDTH               ];	\
-  char4 col2Xreal = input[s][2*tx + 1                              ];	\
-  char4 col2Yreal = input[s][2*tx + 1 + 4*TILE_WIDTH               ];	\
-  char4 col2Ximag = input[s][2*tx + 1 + 2*TILE_WIDTH               ];	\
-  char4 col2Yimag = input[s][2*tx + 1 + 6*TILE_WIDTH               ];	\
-  char4 row1Xreal = input[s][2*ty                    + 8*TILE_WIDTH];	\
-  char4 row1Ximag = input[s][2*ty     + 2*TILE_WIDTH + 8*TILE_WIDTH];	\
-  char4 row1Yreal = input[s][2*ty     + 4*TILE_WIDTH + 8*TILE_WIDTH];	\
-  char4 row1Yimag = input[s][2*ty     + 6*TILE_WIDTH + 8*TILE_WIDTH];	\
-  char4 row2Xreal = input[s][2*ty + 1                + 8*TILE_WIDTH];	\
-  char4 row2Yreal = input[s][2*ty + 1 + 4*TILE_WIDTH + 8*TILE_WIDTH];	\
-  char4 row2Ximag = input[s][2*ty + 1 + 2*TILE_WIDTH + 8*TILE_WIDTH];	\
-  char4 row2Yimag = input[s][2*ty + 1 + 6*TILE_WIDTH + 8*TILE_WIDTH];
+ {int col1Xreal = input[s][2*tx                                  ];	\
+  int col1Ximag = input[s][2*tx     + 2*TILE_WIDTH               ];	\
+  int col1Yreal = input[s][2*tx     + 4*TILE_WIDTH               ];	\
+  int col1Yimag = input[s][2*tx     + 6*TILE_WIDTH               ];	\
+  int col2Xreal = input[s][2*tx + 1                              ];	\
+  int col2Yreal = input[s][2*tx + 1 + 4*TILE_WIDTH               ];	\
+  int col2Ximag = input[s][2*tx + 1 + 2*TILE_WIDTH               ];	\
+  int col2Yimag = input[s][2*tx + 1 + 6*TILE_WIDTH               ];	\
+  int row1Xreal = input[s][2*ty                    + 8*TILE_WIDTH];	\
+  int row1Ximag = input[s][2*ty     + 2*TILE_WIDTH + 8*TILE_WIDTH];	\
+  int row1Yreal = input[s][2*ty     + 4*TILE_WIDTH + 8*TILE_WIDTH];	\
+  int row1Yimag = input[s][2*ty     + 6*TILE_WIDTH + 8*TILE_WIDTH];	\
+  int row2Xreal = input[s][2*ty + 1                + 8*TILE_WIDTH];	\
+  int row2Yreal = input[s][2*ty + 1 + 4*TILE_WIDTH + 8*TILE_WIDTH];	\
+  int row2Ximag = input[s][2*ty + 1 + 2*TILE_WIDTH + 8*TILE_WIDTH];	\
+  int row2Yimag = input[s][2*ty + 1 + 6*TILE_WIDTH + 8*TILE_WIDTH];
 #else
 #error COMPLEX_BLOCK_SIZE must be 1 or 32
 #endif // COMPLEX_BLOCK_SIZE
 
-inline __device__ void dp4a(int &c, const char4 &a, const char4 &b) {
+inline __device__ void dp4a(int &c, const int &a, const int &b) {
 #if __CUDA_ARCH__ >= 610
-  int &ai = *((int*)&a);
-  int &bi = *((int*)&b);
-  asm("dp4a.s32.s32 %0, %1, %2, %0;" : "+r"(c) : "r"(ai), "r"(bi));
+  asm("dp4a.s32.s32 %0, %1, %2, %3;" : "+r"(c) : "r"(a), "r"(b), "r"(c));
 #else
-  c += a.x*b.x;
-  c += a.y*b.y;
-  c += a.z*b.z;
-  c += a.w*b.w;
-#endif
-}
-
-inline __device__ void dp4s(int &c, const char4 &a, const char4 &b) {
-#if __CUDA_ARCH__ >= 610
-  int &ai = *((int*)&a);
-  int &bi = *((int*)&b);
-  asm("dp4a.s32.s32 %0, %1, %2, %3;" : "+r"(c) : "r"(ai), "r"(bi), "r"(-c));
-#else
-  c -= a.x*b.x;
-  c -= a.y*b.y;
-  c -= a.z*b.z;
-  c -= a.w*b.w;  
+  char4 &a4 = *((char4*)&a);
+  char4 &b4 = *((char4*)&b);
+  c += a4.x*b4.x;
+  c += a4.y*b4.y;
+  c += a4.z*b4.z;
+  c += a4.w*b4.w;
 #endif
 }
 
@@ -90,65 +77,65 @@ inline __device__ void dp4s(int &c, const char4 &a, const char4 &b) {
   TWO_BY_TWO_PRELOAD(s)							\
   dp4a(sum11XXreal,row1Xreal,col1Xreal);				\
   dp4a(sum11XXreal,row1Ximag,col1Ximag);				\
-  dp4a(sum11XXimag,row1Ximag,col1Xreal);				\
-  dp4s(sum11XXimag,row1Xreal,col1Ximag);				\
+  dp4a(sum11XXimag1,row1Ximag,col1Xreal);				\
+  dp4a(sum11XXimag2,row1Xreal,col1Ximag);				\
   dp4a(sum11XYreal,row1Xreal,col1Yreal);				\
   dp4a(sum11XYreal,row1Ximag,col1Yimag);				\
-  dp4a(sum11XYimag,row1Ximag,col1Yreal);				\
-  dp4s(sum11XYimag,row1Xreal,col1Yimag);				\
+  dp4a(sum11XYimag1,row1Ximag,col1Yreal);				\
+  dp4a(sum11XYimag2,row1Xreal,col1Yimag);				\
   dp4a(sum11YXreal,row1Yreal,col1Xreal);				\
   dp4a(sum11YXreal,row1Yimag,col1Ximag);				\
-  dp4a(sum11YXimag,row1Yimag,col1Xreal);				\
-  dp4s(sum11YXimag,row1Yreal,col1Ximag);				\
+  dp4a(sum11YXimag1,row1Yimag,col1Xreal);				\
+  dp4a(sum11YXimag2,row1Yreal,col1Ximag);				\
   dp4a(sum11YYreal,row1Yreal,col1Yreal);				\
   dp4a(sum11YYreal,row1Yimag,col1Yimag);				\
-  dp4a(sum11YYimag,row1Yimag,col1Yreal);				\
-  dp4s(sum11YYimag,row1Yreal,col1Yimag);				\
+  dp4a(sum11YYimag1,row1Yimag,col1Yreal);				\
+  dp4a(sum11YYimag2,row1Yreal,col1Yimag);				\
   dp4a(sum12XXreal,row1Xreal,col2Xreal);				\
   dp4a(sum12XXreal,row1Ximag,col2Ximag);				\
-  dp4a(sum12XXimag,row1Ximag,col2Xreal);				\
-  dp4s(sum12XXimag,row1Xreal,col2Ximag);				\
+  dp4a(sum12XXimag1,row1Ximag,col2Xreal);				\
+  dp4a(sum12XXimag2,row1Xreal,col2Ximag);				\
   dp4a(sum12XYreal,row1Xreal,col2Yreal);				\
   dp4a(sum12XYreal,row1Ximag,col2Yimag);				\
-  dp4a(sum12XYimag,row1Ximag,col2Yreal);				\
-  dp4s(sum12XYimag,row1Xreal,col2Yimag);				\
+  dp4a(sum12XYimag1,row1Ximag,col2Yreal);				\
+  dp4a(sum12XYimag2,row1Xreal,col2Yimag);				\
   dp4a(sum12YXreal,row1Yreal,col2Xreal);				\
   dp4a(sum12YXreal,row1Yimag,col2Ximag);				\
-  dp4a(sum12YXimag,row1Yimag,col2Xreal);				\
-  dp4s(sum12YXimag,row1Yreal,col2Ximag);				\
+  dp4a(sum12YXimag1,row1Yimag,col2Xreal);				\
+  dp4a(sum12YXimag2,row1Yreal,col2Ximag);				\
   dp4a(sum12YYreal,row1Yreal,col2Yreal);				\
   dp4a(sum12YYreal,row1Yimag,col2Yimag);				\
-  dp4a(sum12YYimag,row1Yimag,col2Yreal);				\
-  dp4s(sum12YYimag,row1Yreal,col2Yimag);				\
+  dp4a(sum12YYimag1,row1Yimag,col2Yreal);				\
+  dp4a(sum12YYimag2,row1Yreal,col2Yimag);				\
   dp4a(sum21XXreal,row2Xreal,col1Xreal);				\
   dp4a(sum21XXreal,row2Ximag,col1Ximag);				\
-  dp4a(sum21XXimag,row2Ximag,col1Xreal);				\
-  dp4s(sum21XXimag,row2Xreal,col1Ximag);				\
+  dp4a(sum21XXimag1,row2Ximag,col1Xreal);				\
+  dp4a(sum21XXimag2,row2Xreal,col1Ximag);				\
   dp4a(sum21XYreal,row2Xreal,col1Yreal);				\
   dp4a(sum21XYreal,row2Ximag,col1Yimag);				\
-  dp4a(sum21XYimag,row2Ximag,col1Yreal);				\
-  dp4s(sum21XYimag,row2Xreal,col1Yimag);				\
+  dp4a(sum21XYimag1,row2Ximag,col1Yreal);				\
+  dp4a(sum21XYimag2,row2Xreal,col1Yimag);				\
   dp4a(sum21YXreal,row2Yreal,col1Xreal);				\
   dp4a(sum21YXreal,row2Yimag,col1Ximag);				\
-  dp4a(sum21YXimag,row2Yimag,col1Xreal);				\
-  dp4s(sum21YXimag,row2Yreal,col1Ximag);				\
+  dp4a(sum21YXimag1,row2Yimag,col1Xreal);				\
+  dp4a(sum21YXimag2,row2Yreal,col1Ximag);				\
   dp4a(sum21YYreal,row2Yreal,col1Yreal);				\
   dp4a(sum21YYreal,row2Yimag,col1Yimag);				\
-  dp4a(sum21YYimag,row2Yimag,col1Yreal);				\
-  dp4s(sum21YYimag,row2Yreal,col1Yimag);				\
+  dp4a(sum21YYimag1,row2Yimag,col1Yreal);				\
+  dp4a(sum21YYimag2,row2Yreal,col1Yimag);				\
   dp4a(sum22XXreal,row2Xreal,col2Xreal);				\
   dp4a(sum22XXreal,row2Ximag,col2Ximag);				\
-  dp4a(sum22XXimag,row2Ximag,col2Xreal);				\
-  dp4s(sum22XXimag,row2Xreal,col2Ximag);				\
+  dp4a(sum22XXimag1,row2Ximag,col2Xreal);				\
+  dp4a(sum22XXimag2,row2Xreal,col2Ximag);				\
   dp4a(sum22XYreal,row2Xreal,col2Yreal);				\
   dp4a(sum22XYreal,row2Ximag,col2Yimag);				\
-  dp4a(sum22XYimag,row2Ximag,col2Yreal);				\
-  dp4s(sum22XYimag,row2Xreal,col2Yimag);				\
+  dp4a(sum22XYimag1,row2Ximag,col2Yreal);				\
+  dp4a(sum22XYimag2,row2Xreal,col2Yimag);				\
   dp4a(sum22YXreal,row2Yreal,col2Xreal);				\
   dp4a(sum22YXreal,row2Yimag,col2Ximag);				\
-  dp4a(sum22YXimag,row2Yimag,col2Xreal);				\
-  dp4s(sum22YXimag,row2Yreal,col2Ximag);				\
+  dp4a(sum22YXimag1,row2Yimag,col2Xreal);				\
+  dp4a(sum22YXimag2,row2Yreal,col2Ximag);				\
   dp4a(sum22YYreal,row2Yreal,col2Yreal);				\
   dp4a(sum22YYreal,row2Yimag,col2Yimag);				\
-  dp4a(sum22YYimag,row2Yimag,col2Yreal);				\
-  dp4s(sum22YYimag,row2Yreal,col2Yimag);}
+  dp4a(sum22YYimag1,row2Yimag,col2Yreal);				\
+  dp4a(sum22YYimag2,row2Yreal,col2Yimag);}

--- a/src/shared_transfer_4_dp4a.cuh
+++ b/src/shared_transfer_4_dp4a.cuh
@@ -8,11 +8,10 @@
 
 // Read char4 from global, write int to shared memory avoid bank conflict.
 #define LOAD(s, t)							\
-  { int real = tex1Dfetch(tex1dchar4, array_index + (t)*NFREQUENCY*NSTATION*NPOL); \
-    int imag = tex1Dfetch(tex1dchar4, array_index + (NTIME_PIPE/4 + t)*NFREQUENCY*NSTATION*NPOL); \
+  { int2 c = tex1Dfetch(tex1dchar4, array_index + (t)*NFREQUENCY*NSTATION*NPOL); \
     CUBE_ADD_BYTES(4*sizeof(ComplexInput));				\
-    *(input##s##_p) = real;						\
-    *(input##s##_p + 4*TILE_WIDTH) = imag;}
+    *(input##s##_p) = c.x;						\
+    *(input##s##_p + 4*TILE_WIDTH) = c.y;}
 
 #else
 
@@ -22,25 +21,22 @@
 // Read float2 from global, write individual floats
 // to shared memory avoid bank conflict.
 #define LOAD(s, t)							\
-  {  int4 real, imag;							\
+  {  int4 c;								\
     asm("tex.2d.v4.s32.s32 {%0, %1, %2, %3}, [tex2dchar4, {%4, %5}];" :	\
-	"=r"(real.x), "=r"(real.y), "=r"(real.z), "=r"(real.w) : "r"(array_index), "r"(t)); \
-    asm("tex.2d.v4.s32.s32 {%0, %1, %2, %3}, [tex2dchar4, {%4, %5}];" :	\
-	"=r"(imag.x), "=r"(imag.y), "=r"(imag.z), "=r"(imag.w) : "r"(array_index), "r"(t + NTIME_PIPE/4)); \
+	"=r"(c.x), "=r"(c.y), "=r"(c.z), "=r"(c.w) : "r"(array_index), "r"(t)); \
     CUBE_ADD_BYTES(4*sizeof(ComplexInput));				\
-    *(input##s##_p) = real.x;						\
-    *(input##s##_p + 4*TILE_WIDTH) = imag.x;}
+    *(input##s##_p) = c.x;						\
+    *(input##s##_p + 4*TILE_WIDTH) = c.y;}
 
 #else
 
 // Read char4 from global, write individual floats
 // to shared memory avoid bank conflict.
 #define LOAD(s, t)							\
-  { int real = tex2D(tex2dchar4, array_index, t);			\
-    int imag = tex2D(tex2dchar4, array_index, t + NTIME_PIPE/4);	\
+  { int2 c = tex2D(tex2dchar4, array_index, t);				\
     CUBE_ADD_BYTES(4*sizeof(ComplexInput));				\
-    *(input##s##_p) = *((int*)&real);					\
-    *(input##s##_p + 4*TILE_WIDTH) = *((int*)&imag);}
+    *(input##s##_p) = c.x;						\
+    *(input##s##_p + 4*TILE_WIDTH) = c.y;}
 #endif  // use float texture coordinates
 
 #endif

--- a/src/xgpu.h
+++ b/src/xgpu.h
@@ -12,10 +12,6 @@ extern "C" {
 // point (i.e. floats).
 #define FIXED_POINT
 
-// If DP4A is defined, the library does all computation using native
-// 8-bit integer multiplication and 32-bit accumulation
-#define DP4A
-
 // set the data type accordingly
 #ifndef FIXED_POINT
 typedef float ReImInput;

--- a/src/xgpu.h
+++ b/src/xgpu.h
@@ -12,6 +12,10 @@ extern "C" {
 // point (i.e. floats).
 #define FIXED_POINT
 
+// If DP4A is defined, the library does all computation using native
+// 8-bit integer multiplication and 32-bit accumulation
+#define DP4A
+
 // set the data type accordingly
 #ifndef FIXED_POINT
 typedef float ReImInput;
@@ -24,10 +28,17 @@ typedef struct ComplexInputStruct {
   ReImInput imag;
 } ComplexInput;
 
+#ifndef DP4A
 typedef struct ComplexStruct {
   float real;
   float imag;
 } Complex;
+#else
+typedef struct ComplexStruct {
+  int real;
+  int imag;
+} Complex;
+#endif
 
 // Used to indicate the size and type of input data
 #define XGPU_INT8    (0)
@@ -66,6 +77,8 @@ typedef struct XGPUInfoStruct {
   unsigned int ntimepipe;
   // Type of input.  One of XGPU_INT8, XGPU_FLOAT32, XGPU_INT32.
   unsigned int input_type;
+  // Type of computation.  One of XGPU_INT8 or XGPU_FLOAT32
+  unsigned int compute_type;
   // Number of ComplexInput elements in input vector
   long long unsigned int vecLength;
   // Number of ComplexInput elements per transfer to GPU
@@ -216,6 +229,8 @@ void xgpuRandomComplex(ComplexInput* random_num, long long unsigned int length);
 void xgpuReorderMatrix(Complex *matrix);
 
 void xgpuCheckResult(Complex *gpu, Complex *cpu, int verbose, ComplexInput *array_h);
+
+void xgpuSwizzleInput(ComplexInput *out, const ComplexInput *in);
 
 void xgpuExtractMatrix(Complex *matrix, Complex *packed);
 

--- a/src/xgpu.h
+++ b/src/xgpu.h
@@ -20,7 +20,7 @@ extern "C" {
 #ifndef FIXED_POINT
 typedef float ReImInput;
 #else
-typedef char ReImInput;
+typedef signed char ReImInput;
 #endif // FIXED_POINT
 
 typedef struct ComplexInputStruct {

--- a/src/xgpu_info.h
+++ b/src/xgpu_info.h
@@ -17,16 +17,22 @@
 #endif
 
 #ifndef NTIME
-#define NTIME 1000
+#define NTIME 1024
 #endif
 
 #ifndef NTIME_PIPE
-#define NTIME_PIPE 100
+#define NTIME_PIPE 128
 #endif
 
 // Ensure that NTIME_PIPE is a multiple of 4
+#ifndef DP4A
 #if (NTIME_PIPE/4)*4 != NTIME_PIPE
 #error NTIME_PIPE must be a multiple of 4
+#endif
+#else
+#if (NTIME_PIPE/16)*16 != NTIME_PIPE
+#error For DP4A: NTIME_PIPE must be a multiple of 16
+#endif
 #endif
 
 // Ensure that NTIME is a multiple of NTIME_PIPE

--- a/src/xgpuinfo.c
+++ b/src/xgpuinfo.c
@@ -29,6 +29,13 @@ int main(int argc, char** argv)
     default: printf("<unknown type code: %d>\n", xgpu_info.input_type);
   }
 
+  printf("Type of computation: ");
+  switch(xgpu_info.compute_type) {
+    case XGPU_INT8:    printf("8 bit multiply, 32-bit accumulate\n"); break;
+    case XGPU_FLOAT32: printf("FP32 multiply, FP32 accumulate\n"); break;
+    default: printf("<unknown type code: %d>\n", xgpu_info.compute_type);
+  }
+
   printf("Number of ComplexInput elements in GPU input vector: %llu\n",
       xgpu_info.vecLength);
 


### PR DESCRIPTION
This pull request adds support for using the `dp4a` instruction for native 8-bit multiply / 32-bit accumulate, present on all Pascal (excluding GP100 and GP10B) and Volta GPUs.
* This can accelerate xGPU by up to 4x versus the usual fp32 computation
* When using dp4a, the entire computation is pure integer, so the internal xGPU error checking is exact, not subject to rounding 
* Enabled with the `DP4A=yes` make command-line option
* Note that DP4A requires a different input data order, in particular the input data is swizzled with respect to time: `input[time/4][channel][station][pol][complexity][time%4]`.  At present xGPU offers no functionality to do this swizzling and expects the user to supply the data in this order.  The internal unit test does this swizzling on the host prior to copying to the GPU.
* Note that when using dp4a, there is the additional constraint that the `NTIME_PIPE` dimension must be a multiple of 16 (as opposed to 4).

Other changes in this pull request
* Default compilation set to Kepler sm_35 architecture since sm_20 has been removed in CUDA 9.x
* Remove `-Xptx abi=no` compilation option since this no longer exists with CUDA 9.x 
* Fix char sign ambiguity on POWER host processors


As an example of dp4a in action, below we show the performance 512 stations with and without dp4a on a Tesla V100 GPU.

**without dp4a**
```
$ ./bench CUDA_DIR=$CUDA_HOME NTIME=8192 NTIME_PIPE=1024 NSTATION=512 NFREQUENCY=10 CUDA_ARCH=sm_70 DP4A=no
===============================
CUBE Kernel profile
===============================

kernel                                  :    calls    time/s   Gflops Gflops/s  GiBytes GiBytes/s
cudaMemcpyHostToDevice_20971520         :        8  0.013626    0.000    0.000    0.156   11.467
shared2x2                               :        8  0.031117  344.268 11063.521    5.646  181.434
cudaMemcpyDeviceToHost_42024960         :        1  0.003229    0.000    0.000    0.039   12.123

Total                                   :       17  0.047972  344.268 7176.499    5.841  121.762

===============================
CUBE Asynchronous block profile
===============================

kernel                                  :    calls    time/s   Gflops Gflops/s  GiBytes GiBytes/s
ENTIRE_PIPELINE                         :        1  0.036123  344.268 9530.373    5.841  161.700
PIPELINE_LOOP                           :        1  0.027190  301.235 11078.789    5.077  186.712
```

**with dp4a**
```
$ ./bench CUDA_DIR=$CUDA_HOME NTIME=8192 NTIME_PIPE=1024 NSTATION=512 NFREQUENCY=10 CUDA_ARCH=sm_70 DP4A=yes
===============================
CUBE Kernel profile
===============================

kernel                                  :    calls    time/s   Gflops Gflops/s  GiBytes GiBytes/s
cudaMemcpyHostToDevice_20971520         :        8  0.013606    0.000    0.000    0.156   11.484
shared2x2                               :        8  0.007736  344.268 44500.285    5.646  729.772
cudaMemcpyDeviceToHost_42024960         :        1  0.003221    0.000    0.000    0.039   12.149

Total                                   :       17  0.024564  344.268 14015.052    5.841  237.791

===============================
CUBE Asynchronous block profile
===============================

kernel                                  :    calls    time/s   Gflops Gflops/s  GiBytes GiBytes/s
ENTIRE_PIPELINE                         :        1  0.017969  344.268 19158.621    5.841  325.061
PIPELINE_LOOP                           :        1  0.011969  301.235 25168.955    5.077  424.176
```